### PR TITLE
Update Spanish translations for router and SMS service

### DIFF
--- a/custom_components/tplink_router/translations/es.json
+++ b/custom_components/tplink_router/translations/es.json
@@ -16,13 +16,33 @@
   "options": {
     "step": {
       "init": {
-        "description": "Editar parámetros del router.",
+        "description": "Editar parámetros del router",
         "data": {
           "host": "Host",
           "username": "Usuario",
           "password": "Contraseña",
           "scan_interval": "Intervalo de escaneo para actualizaciones en segundos",
           "verify_ssl": "Verificar SSL para conexión https"
+        }
+      }
+    }
+  },
+  "services": {
+    "send_sms": {
+      "name": "Enviar SMS",
+      "description": "Enviar SMS",
+      "fields": {
+        "number": {
+          "name": "Teléfono",
+          "description": "Número de teléfono"
+        },
+        "text": {
+          "name": "Mensaje",
+          "description": "Texto"
+        },
+        "device": {
+          "name": "Router",
+          "description": "Selecciona el router TP-Link para enviar SMS"
         }
       }
     }


### PR DESCRIPTION
Hi @AlexandrErohin,

In this PR the Spanish translation is added, following the steps indicated, removed period from the router parameters description and added SMS service translations

The .json file has been checked and validated

![image](https://github.com/user-attachments/assets/9380d7df-b818-4c0a-a9e4-899a32b94f6c)