### PR TITLE
Improve request logout safety to prevent update failures

### DIFF
--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -70,10 +70,14 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
     @staticmethod
     def request(router: AbstractRouter, callback: Callable):
         router.authorize()
-        data = callback()
-        router.logout()
-
-        return data
+        try:
+            return callback()
+        finally:
+            try:
+                router.logout()
+            except Exception:
+                # Do not block updates if logout fails.
+                pass
 
     async def reboot(self) -> None:
         await self.hass.async_add_executor_job(TPLinkRouterCoordinator.request, self.router, self.router.reboot)


### PR DESCRIPTION
## Summary
  - Make logout best‑effort in `TPLinkRouterCoordinator.request`.
  - Don’t let a logout failure kill a successful update.

  ## Why
  While testing on a BE230 I kept hitting cases where the logout call fails.
  The request itself succeeds, but the exception from logout aborts the
  update cycle and I end up with no refreshed data. This change keeps the
  update loop alive and still surfaces real request errors.

  ## Scope
  - Same authorize -> callback -> logout flow.
  - Only changes how logout errors are handled.