### PR TITLE
Add VPN server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv
 .idea
 .DS_Store
+__pycache__/

--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -48,20 +48,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 lte_stat = client.get_lte_status()
             except Exception:
                 pass
+        # Check if router is vpn_server compatible
+        vpn_server_stat = None
+        if hasattr(client, "get_vpn_status"):
+            try:
+                vpn_server_stat = client.get_vpn_status()
+            except Exception:
+                pass
+        # Check if router is vpn_client compatible
         vpn_client_stat = None
         if hasattr(client, "get_vpn_client_status"):
             try:
                 vpn_client_stat = client.get_vpn_client_status()
             except Exception:
                 pass
-        return firm, stat, lte_stat, vpn_client_stat
+        return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat 
 
-    firmware, status, lte_status, vpn_client_status = await hass.async_add_executor_job(
+    firmware, status, lte_status, vpn_server_stat, vpn_client_status = await hass.async_add_executor_job(
         TPLinkRouterCoordinator.request, client, callback
     )
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
-                                          lte_status, _LOGGER, entry.entry_id, vpn_client_status)
+                                          lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status)
 
     await coordinator.async_config_entry_first_refresh()
     _async_add_listeners(hass, coordinator)

--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -48,20 +48,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 lte_stat = client.get_lte_status()
             except Exception:
                 pass
-        vpn_stat = None
+        vpn_client_stat = None
         if hasattr(client, "get_vpn_client_status"):
             try:
-                vpn_stat = client.get_vpn_client_status()
+                vpn_client_stat = client.get_vpn_client_status()
             except Exception:
                 pass
-        return firm, stat, lte_stat, vpn_stat
+        return firm, stat, lte_stat, vpn_client_stat
 
-    firmware, status, lte_status, vpn_status = await hass.async_add_executor_job(
+    firmware, status, lte_status, vpn_client_status = await hass.async_add_executor_job(
         TPLinkRouterCoordinator.request, client, callback
     )
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
-                                          lte_status, _LOGGER, entry.entry_id, vpn_status)
+                                          lte_status, _LOGGER, entry.entry_id, vpn_client_status)
 
     await coordinator.async_config_entry_first_refresh()
     _async_add_listeners(hass, coordinator)

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -5,6 +5,7 @@ from logging import Logger
 from collections.abc import Callable
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from tplinkrouterc6u import (
+    VPN,
     TplinkRouterProvider,
     AbstractRouter,
     Firmware,
@@ -93,6 +94,11 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
         def callback():
             self.router.set_wifi(wifi, enable)
 
+        await self.hass.async_add_executor_job(TPLinkRouterCoordinator.request, self.router, callback)
+
+    async def set_vpn_server(self, kind: VPN, enable: bool) -> None:
+        def callback():
+            self.router.set_vpn(kind, enable)
         await self.hass.async_add_executor_job(TPLinkRouterCoordinator.request, self.router, callback)
 
     async def set_vpn_client(self, enable: bool) -> None:

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -13,6 +13,7 @@ from tplinkrouterc6u import (
     LTEStatus,
     SMS,
     VpnClientStatus,
+    VPNStatus
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -33,7 +34,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             lte_status: LTEStatus | None,
             logger: Logger,
             unique_id: str,
-            # vpn_status: VpnStatus | None = None,
+            vpn_server_status: VPNStatus | None = None,
             vpn_client_status: VpnClientStatus | None = None,
     ) -> None:
         self.router = router
@@ -52,7 +53,8 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             hw_version=firmware.hardware_version,
         )
 
-        self.vpn_client_status: VpnClientStatus | None = vpn_client_status
+        self.vpn_server_status = vpn_server_status
+        self.vpn_client_status = vpn_client_status
 
         self.scan_stopped_at: datetime | None = None
         self._last_update_time: datetime | None = None
@@ -122,13 +124,15 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.router,
                 self.router.get_lte_status,
             )
+        if self.vpn_server_status is not None:
+            self.vpn_server_status = await self.hass.async_add_executor_job(
+                TPLinkRouterCoordinator.request, self.router, self.router.get_vpn_status
+            )
         if self.vpn_client_status is not None:
-            new_vpn_client_status = await self.hass.async_add_executor_job(
+            self.vpn_client_status = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request, self.router, self.router.get_vpn_client_status
             )
-            self.vpn_client_status.enabled = new_vpn_client_status.enabled
-            self.vpn_client_status.servers = new_vpn_client_status.servers
-            self.vpn_client_status.devices = new_vpn_client_status.devices
+        
         await self._update_new_sms()
         self._last_update_time = datetime.now()
 

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -33,7 +33,8 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             lte_status: LTEStatus | None,
             logger: Logger,
             unique_id: str,
-            vpn_status: VpnClientStatus | None = None,
+            # vpn_status: VpnStatus | None = None,
+            vpn_client_status: VpnClientStatus | None = None,
     ) -> None:
         self.router = router
         self.unique_id = unique_id
@@ -51,7 +52,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             hw_version=firmware.hardware_version,
         )
 
-        self.vpn_status: VpnClientStatus | None = vpn_status
+        self.vpn_client_status: VpnClientStatus | None = vpn_client_status
 
         self.scan_stopped_at: datetime | None = None
         self._last_update_time: datetime | None = None
@@ -121,13 +122,13 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.router,
                 self.router.get_lte_status,
             )
-        if self.vpn_status is not None:
-            new_vpn_status = await self.hass.async_add_executor_job(
+        if self.vpn_client_status is not None:
+            new_vpn_client_status = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request, self.router, self.router.get_vpn_client_status
             )
-            self.vpn_status.enabled = new_vpn_status.enabled
-            self.vpn_status.servers = new_vpn_status.servers
-            self.vpn_status.devices = new_vpn_status.devices
+            self.vpn_client_status.enabled = new_vpn_client_status.enabled
+            self.vpn_client_status.servers = new_vpn_client_status.servers
+            self.vpn_client_status.devices = new_vpn_client_status.devices
         await self._update_new_sms()
         self._last_update_time = datetime.now()
 

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -13,216 +13,287 @@ from .const import DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkRouterCoordinator
-from tplinkrouterc6u import Status, LTEStatus
+from tplinkrouterc6u import Status, LTEStatus, VPNStatus
 
 
 @dataclass
-class TPLinkRouterSensorRequiredKeysMixin:
-    value: Callable[[Status], Any]
+class TPLinkRouterSensorConfigBase[T]:
+    description: SensorEntityDescription
+    value: Callable[[T], Any]
+    sensor_type: str
 
 
 @dataclass
-class TPLinkRouterLTESensorRequiredKeysMixin:
-    value: Callable[[LTEStatus], Any]
-
-
-@dataclass
-class TPLinkRouterSensorEntityDescription(
-    SensorEntityDescription, TPLinkRouterSensorRequiredKeysMixin
-):
-    """A class that describes sensor entities."""
-
+class TPLinkRouterSensorConfig(TPLinkRouterSensorConfigBase[Status]):
     sensor_type: str = "status"
 
 
 @dataclass
-class TPLinkRouterLTESensorEntityDescription(
-    SensorEntityDescription, TPLinkRouterLTESensorRequiredKeysMixin
-):
-    """A class that describes LTEStatus entities."""
-
+class TPLinkRouterLTESensorConfig(TPLinkRouterSensorConfigBase[LTEStatus]):
     sensor_type: str = "lte_status"
 
 
-SENSOR_TYPES: tuple[TPLinkRouterSensorEntityDescription, ...] = (
-    TPLinkRouterSensorEntityDescription(
-        key="guest_wifi_clients_total",
-        name="Total guest wifi clients",
-        icon="mdi:account-multiple",
-        state_class=SensorStateClass.TOTAL,
+@dataclass
+class TPLinkRouterVPNServerSensorConfig(TPLinkRouterSensorConfigBase[VPNStatus]):
+    sensor_type: str = "vpn_server_status"
+
+
+SENSOR_TYPES = (
+    TPLinkRouterSensorConfig(
         value=lambda status: status.guest_clients_total,
+        description=SensorEntityDescription(
+            key="guest_wifi_clients_total",
+            name="Total guest wifi clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="wifi_clients_total",
-        name="Total main wifi clients",
-        icon="mdi:account-multiple",
-        state_class=SensorStateClass.TOTAL,
+    TPLinkRouterSensorConfig(
         value=lambda status: status.wifi_clients_total,
+        description=SensorEntityDescription(
+            key="wifi_clients_total",
+            name="Total main wifi clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="wired_clients_total",
-        name="Total wired clients",
-        icon="mdi:account-multiple",
-        state_class=SensorStateClass.TOTAL,
+    TPLinkRouterSensorConfig(
         value=lambda status: status.wired_total,
+        description=SensorEntityDescription(
+            key="wired_clients_total",
+            name="Total wired clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="iot_clients_total",
-        name="Total IoT clients",
-        icon="mdi:account-multiple",
-        state_class=SensorStateClass.TOTAL,
+    TPLinkRouterSensorConfig(
         value=lambda status: status.iot_clients_total,
+        description=SensorEntityDescription(
+            key="iot_clients_total",
+            name="Total IoT clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="clients_total",
-        name="Total clients",
-        icon="mdi:account-multiple",
-        state_class=SensorStateClass.TOTAL,
+    TPLinkRouterSensorConfig(
         value=lambda status: status.clients_total,
+        description=SensorEntityDescription(
+            key="clients_total",
+            name="Total clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="cpu_used",
-        name="CPU used",
-        icon="mdi:cpu-64-bit",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-        suggested_display_precision=1,
-        value=lambda status: (status.cpu_usage * 100) if status.cpu_usage is not None else None,
+    TPLinkRouterSensorConfig(
+        value=lambda status: (
+            (status.cpu_usage * 100) if status.cpu_usage is not None else None
+        ),
+        description=SensorEntityDescription(
+            key="cpu_used",
+            name="CPU used",
+            icon="mdi:cpu-64-bit",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=PERCENTAGE,
+            suggested_display_precision=1,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="memory_used",
-        name="Memory used",
-        icon="mdi:memory",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-        suggested_display_precision=1,
-        value=lambda status: (status.mem_usage * 100) if status.mem_usage is not None else None,
+    TPLinkRouterSensorConfig(
+        value=lambda status: (
+            (status.mem_usage * 100) if status.mem_usage is not None else None
+        ),
+        description=SensorEntityDescription(
+            key="memory_used",
+            name="Memory used",
+            icon="mdi:memory",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=PERCENTAGE,
+            suggested_display_precision=1,
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="conn_type",
-        name="Connection Type",
-        icon="mdi:wan",
+    TPLinkRouterSensorConfig(
         value=lambda status: status.conn_type,
+        description=SensorEntityDescription(
+            key="conn_type",
+            name="Connection Type",
+            icon="mdi:wan",
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="wan_ipv4_addr",
-        name="WAN IPv4 Address",
-        icon="mdi:wan",
+    TPLinkRouterSensorConfig(
         value=lambda status: status.wan_ipv4_addr,
+        description=SensorEntityDescription(
+            key="wan_ipv4_addr",
+            name="WAN IPv4 Address",
+            icon="mdi:wan",
+        ),
     ),
-    TPLinkRouterSensorEntityDescription(
-        key="lan_ipv4_addr",
-        name="LAN IPv4 Address",
-        icon="mdi:lan",
+    TPLinkRouterSensorConfig(
         value=lambda status: status.lan_ipv4_addr,
+        description=SensorEntityDescription(
+            key="lan_ipv4_addr",
+            name="LAN IPv4 Address",
+            icon="mdi:lan",
+        ),
     ),
 )
 
-LTE_SENSOR_TYPES: tuple[TPLinkRouterLTESensorEntityDescription, ...] = (
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_enabled",
-        name="LTE Enabled",
-        icon="mdi:sim-outline",
+LTE_SENSOR_TYPES = (
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.enable,
+        description=SensorEntityDescription(
+            key="lte_enabled",
+            name="LTE Enabled",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_connect_status",
-        name="LTE Connection Status",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.connect_status,
+        description=SensorEntityDescription(
+            key="lte_connect_status",
+            name="LTE Connection Status",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_network_type",
-        name="LTE Network Type",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.network_type,
+        description=SensorEntityDescription(
+            key="lte_network_type",
+            name="LTE Network Type",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_network_type_info",
-        name="LTE Network Type Info",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.network_type_info,
+        description=SensorEntityDescription(
+            key="lte_network_type_info",
+            name="LTE Network Type Info",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_sim_status",
-        name="LTE SIM Status",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.sim_status,
+        description=SensorEntityDescription(
+            key="lte_sim_status",
+            name="LTE SIM Status",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_sim_status_info",
-        name="LTE SIM Status Info",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.sim_status_info,
+        description=SensorEntityDescription(
+            key="lte_sim_status_info",
+            name="LTE SIM Status Info",
+            icon="mdi:sim-outline",
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_total_statistics",
-        name="LTE Total Statistics",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.TOTAL,
-        native_unit_of_measurement=UnitOfInformation.BYTES,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.total_statistics,
+        description=SensorEntityDescription(
+            key="lte_total_statistics",
+            name="LTE Total Statistics",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.TOTAL,
+            native_unit_of_measurement=UnitOfInformation.BYTES,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_cur_rx_speed",
-        name="LTE Current RX Speed",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.cur_rx_speed,
+        description=SensorEntityDescription(
+            key="lte_cur_rx_speed",
+            name="LTE Current RX Speed",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_cur_tx_speed",
-        name="LTE Current TX Speed",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.cur_tx_speed,
+        description=SensorEntityDescription(
+            key="lte_cur_tx_speed",
+            name="LTE Current TX Speed",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_sms_unread_count",
-        name="Unread SMS",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.TOTAL,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.sms_unread_count,
+        description=SensorEntityDescription(
+            key="lte_sms_unread_count",
+            name="Unread SMS",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_sig_level",
-        name="LTE Signal Level",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-        value=lambda status: status.sig_level * 25 if status.sig_level is not None else None,
+    TPLinkRouterLTESensorConfig(
+        value=lambda status: (
+            status.sig_level * 25 if status.sig_level is not None else None
+        ),
+        description=SensorEntityDescription(
+            key="lte_sig_level",
+            name="LTE Signal Level",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=PERCENTAGE,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_rsrp",
-        name="LTE RSRP",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.rsrp,
+        description=SensorEntityDescription(
+            key="lte_rsrp",
+            name="LTE RSRP",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_rsrq",
-        name="LTE RSRQ",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.rsrq,
+        description=SensorEntityDescription(
+            key="lte_rsrq",
+            name="LTE RSRQ",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_snr",
-        name="LTE SNR",
-        icon="mdi:sim-outline",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    TPLinkRouterLTESensorConfig(
         value=lambda status: 0.1 * status.snr if status.snr is not None else None,
+        description=SensorEntityDescription(
+            key="lte_snr",
+            name="LTE SNR",
+            icon="mdi:sim-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
     ),
-    TPLinkRouterLTESensorEntityDescription(
-        key="lte_isp_name",
-        name="LTE ISP Name",
-        icon="mdi:sim-outline",
+    TPLinkRouterLTESensorConfig(
         value=lambda status: status.isp_name,
+        description=SensorEntityDescription(
+            key="lte_isp_name",
+            name="LTE ISP Name",
+            icon="mdi:sim-outline",
+        ),
+    ),
+)
+
+VPN_SERVER_SENSOR_TYPES = (
+    TPLinkRouterVPNServerSensorConfig(
+        value=lambda status: status.openvpn_clients_total,
+        description=SensorEntityDescription(
+            key="openvpn_clients_total",
+            name="Total OpenVPN clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
+    ),
+    TPLinkRouterVPNServerSensorConfig(
+        value=lambda status: status.pptpvpn_clients_total,
+        description=SensorEntityDescription(
+            key="pptpvpn_clients_total",
+            name="Total PPTP clients",
+            icon="mdi:account-multiple",
+            state_class=SensorStateClass.TOTAL,
+        ),
     ),
 )
 
@@ -234,42 +305,48 @@ async def async_setup_entry(
 
     sensors = []
 
-    for description in SENSOR_TYPES:
-        sensors.append(TPLinkRouterSensor(coordinator, description))
+    for sensor in SENSOR_TYPES:
+        sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
     if coordinator.lte_status is not None:
-        for description in LTE_SENSOR_TYPES:
-            sensors.append(TPLinkRouterSensor(coordinator, description))
+        for sensor in LTE_SENSOR_TYPES:
+            sensors.append(TPLinkRouterSensor(coordinator, sensor))
+
+    if coordinator.vpn_server_status is not None:
+        for sensor in VPN_SERVER_SENSOR_TYPES:
+            sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
     async_add_entities(sensors, False)
 
 
-class TPLinkRouterSensor(
-    CoordinatorEntity[TPLinkRouterCoordinator], SensorEntity
-):
+class TPLinkRouterSensor(CoordinatorEntity[TPLinkRouterCoordinator], SensorEntity):
     _attr_has_entity_name = True
-    entity_description: TPLinkRouterSensorEntityDescription | TPLinkRouterLTESensorEntityDescription
 
     def __init__(
-            self,
-            coordinator: TPLinkRouterCoordinator,
-            description: TPLinkRouterSensorEntityDescription | TPLinkRouterLTESensorEntityDescription,
+        self,
+        coordinator: TPLinkRouterCoordinator,
+        sensor: TPLinkRouterSensorConfigBase
     ) -> None:
         super().__init__(coordinator)
 
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{description.key}"
-        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{sensor.description.key}"
+        self.entity_description = sensor.description
+        self.sensor = sensor
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        coordinator_data = getattr(self.coordinator, self.entity_description.sensor_type)
-        self._attr_native_value = self.entity_description.value(coordinator_data)
+        coordinator_data = getattr(
+            self.coordinator, self.sensor.sensor_type
+        )
+        self._attr_native_value = self.sensor.value(coordinator_data)
         self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        coordinator_data = getattr(self.coordinator, self.entity_description.sensor_type)
-        return self.entity_description.value(coordinator_data) is not None
+        coordinator_data = getattr(
+            self.coordinator, self.sensor.sensor_type
+        )
+        return self.sensor.value(coordinator_data) is not None

--- a/custom_components/tplink_router/switch.py
+++ b/custom_components/tplink_router/switch.py
@@ -11,93 +11,167 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkRouterCoordinator
-from tplinkrouterc6u import Connection
+from tplinkrouterc6u import VPN, Connection
 from . import vpn_client
 
 
 @dataclass
-class TPLinkRouterSwitchEntityDescriptionMixin:
+class TPLinkRouterSwitchConfigBase:
+    description: SwitchEntityDescription
     method: Callable[[TPLinkRouterCoordinator, bool], Any]
     property: str
-
+    coordinator_key: str
 
 @dataclass
-class TPLinkRouterSwitchEntityDescription(SwitchEntityDescription, TPLinkRouterSwitchEntityDescriptionMixin):
-    """A class that describes sensor entities."""
+class TPLinkRouterStatusSwitchConfig(TPLinkRouterSwitchConfigBase):
+    coordinator_key: str = 'status'
+
+@dataclass
+class TPLinkRouterVPNServerSwitchConfig(TPLinkRouterSwitchConfigBase):
+    coordinator_key: str = 'vpn_server_status'
+
+@dataclass
+class TPLinkRouterVPNClientSwitchConfig(TPLinkRouterSwitchConfigBase):
+    coordinator_key: str = 'vpn_client_status'
 
 
-SWITCH_TYPES = (
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_guest_24g",
-        name="Guest WIFI 2.4G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+
+STATUS_SWITCH_TYPES = (
+    TPLinkRouterStatusSwitchConfig(
         property='guest_2g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.GUEST_2G, value),
+        description=SwitchEntityDescription(
+            key="wifi_guest_24g",
+            name="Guest WIFI 2.4G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_guest_5g",
-        name="Guest WIFI 5G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='guest_5g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.GUEST_5G, value),
+        description=SwitchEntityDescription(
+            key="wifi_guest_5g",
+            name="Guest WIFI 5G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_guest_6g",
-        name="Guest WIFI 6G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='guest_6g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.GUEST_6G, value),
+        description=SwitchEntityDescription(
+            key="wifi_guest_6g",
+            name="Guest WIFI 6G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_24g",
-        name="WIFI 2.4G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='wifi_2g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.HOST_2G, value),
+        description=SwitchEntityDescription(
+            key="wifi_24g",
+            name="WIFI 2.4G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_5g",
-        name="WIFI 5G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='wifi_5g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.HOST_5G, value),
+        description=SwitchEntityDescription(
+            key="wifi_5g",
+            name="WIFI 5G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="wifi_6g",
-        name="WIFI 6G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='wifi_6g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.HOST_6G, value),
+        description=SwitchEntityDescription(
+            key="wifi_6g",
+            name="WIFI 6G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="iot_24g",
-        name="IoT WIFI 2.4G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='iot_2g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.IOT_2G, value),
+        description=SwitchEntityDescription(
+            key="iot_24g",
+            name="IoT WIFI 2.4G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="iot_5g",
-        name="IoT WIFI 5G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='iot_5g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.IOT_5G, value),
+        description=SwitchEntityDescription(
+            key="iot_5g",
+            name="IoT WIFI 5G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
-    TPLinkRouterSwitchEntityDescription(
-        key="iot_6g",
-        name="IoT WIFI 6G",
-        icon="mdi:wifi",
-        entity_category=EntityCategory.CONFIG,
+    TPLinkRouterStatusSwitchConfig(
         property='iot_6g_enable',
         method=lambda coordinator, value: coordinator.set_wifi(Connection.IOT_6G, value),
+        description=SwitchEntityDescription(
+            key="iot_6g",
+            name="IoT WIFI 6G",
+            icon="mdi:wifi",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+)
+
+VPN_SERVER_SWITCH_TYPES = (
+    TPLinkRouterVPNServerSwitchConfig(
+        property='openvpn_enable',
+        method=lambda coordinator, value: coordinator.set_vpn_server(VPN.OPEN_VPN, value),
+        description=SwitchEntityDescription(
+            key="openvpn",
+            name="VPN Server - OpenVPN",
+            icon="mdi:vpn",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+    TPLinkRouterVPNServerSwitchConfig(
+        property='pptpvpn_enable',
+        method=lambda coordinator, value: coordinator.set_vpn_server(VPN.PPTP_VPN, value),
+        description=SwitchEntityDescription(
+            key="pptpvpn",
+            name="VPN Server - PPTP",
+            icon="mdi:vpn",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+    TPLinkRouterVPNServerSwitchConfig(
+        property='ipsecvpn_enable',
+        method=lambda coordinator, value: coordinator.set_vpn_server(VPN.IPSEC, value),
+        description=SwitchEntityDescription(
+            key="ipsec",
+            name="VPN Server - IPSec",
+            icon="mdi:vpn",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+)
+
+VPN_CLIENT_SWITCH_TYPES = (
+    TPLinkRouterVPNClientSwitchConfig(
+        property="enabled",
+        method=lambda coordinator, value: coordinator.set_vpn_client(value),
+        description=SwitchEntityDescription(
+            key="vpn_client",
+            name="VPN Client",
+            icon="mdi:vpn",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
 )
 
@@ -111,60 +185,61 @@ async def async_setup_entry(
 
     switches = []
 
-    for description in SWITCH_TYPES:
-        switches.append(TPLinkRouterSwitchEntity(coordinator, description))
+    for switch in STATUS_SWITCH_TYPES:
+        switches.append(TPLinkRouterSwitch(coordinator, switch))
 
+    # Scan entity has has different turn_on/off logic from the rest of the switches
     switches.append(TPLinkRouterScanEntity(coordinator))
 
+    if coordinator.vpn_server_status is not None:
+        for switch in VPN_SERVER_SWITCH_TYPES:
+            switches.append(TPLinkRouterSwitch(coordinator, switch))
+
     if coordinator.vpn_client_status is not None:
-        vpn_desc = SwitchEntityDescription(
-            key="vpn_client",
-            name="VPN Client",
-            icon="mdi:vpn",
-            entity_category=EntityCategory.CONFIG,
-        )
-        switches.append(TPLinkVpnClientSwitch(coordinator, vpn_desc))
+        for switch in VPN_CLIENT_SWITCH_TYPES:
+            switches.append(TPLinkRouterSwitch(coordinator, switch))
+        # Dynamically register VPN Client devices & servers available on the router
         vpn_client.setup_vpn_entities(coordinator, entry, async_add_entities)
 
     async_add_entities(switches, False)
 
 
-class TPLinkRouterSwitchEntity(
+class TPLinkRouterSwitch(
     CoordinatorEntity[TPLinkRouterCoordinator], SwitchEntity
 ):
-    entity_description: TPLinkRouterSwitchEntityDescription
-
     def __init__(
             self,
             coordinator: TPLinkRouterCoordinator,
-            description: TPLinkRouterSwitchEntityDescription,
+            switch: TPLinkRouterSwitchConfigBase
     ) -> None:
         super().__init__(coordinator)
 
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{description.key}"
-        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{switch.description.key}"
+        self.entity_description = switch.description
+        self.switch = switch
+        self.coordinator_attr = getattr(self.coordinator, switch.coordinator_key)
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return getattr(self.coordinator.status, self.entity_description.property)
+        return getattr(self.coordinator_attr, self.switch.property)
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return getattr(self.coordinator.status, self.entity_description.property) is not None
+        return getattr(self.coordinator_attr, self.switch.property) is not None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self.entity_description.method(self.coordinator, True)
-        setattr(self.coordinator.status, self.entity_description.property, True)
+        await self.switch.method(self.coordinator, True)
+        setattr(self.coordinator_attr, self.switch.property, True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.entity_description.method(self.coordinator, False)
-        setattr(self.coordinator.status, self.entity_description.property, False)
+        await self.switch.method(self.coordinator, False)
+        setattr(self.coordinator_attr, self.switch.property, False)
         self.async_write_ha_state()
 
 
@@ -200,24 +275,3 @@ class TPLinkRouterScanEntity(
         self.coordinator.scan_stopped_at = datetime.now()
         self.async_write_ha_state()
 
-
-class TPLinkVpnClientSwitch(TPLinkRouterSwitchEntity):
-    """Switch for the global VPN client toggle."""
-
-    @property
-    def is_on(self) -> bool:
-        return self.coordinator.vpn_client_status.enabled
-
-    @property
-    def available(self) -> bool:
-        return self.coordinator.vpn_client_status is not None
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.set_vpn_client(True)
-        self.coordinator.vpn_client_status.enabled = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.set_vpn_client(False)
-        self.coordinator.vpn_client_status.enabled = False
-        self.async_write_ha_state()

--- a/custom_components/tplink_router/switch.py
+++ b/custom_components/tplink_router/switch.py
@@ -12,7 +12,7 @@ from .const import DOMAIN
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkRouterCoordinator
 from tplinkrouterc6u import Connection
-from . import vpn
+from . import vpn_client
 
 
 @dataclass
@@ -116,7 +116,7 @@ async def async_setup_entry(
 
     switches.append(TPLinkRouterScanEntity(coordinator))
 
-    if coordinator.vpn_status is not None:
+    if coordinator.vpn_client_status is not None:
         vpn_desc = SwitchEntityDescription(
             key="vpn_client",
             name="VPN Client",
@@ -124,7 +124,7 @@ async def async_setup_entry(
             entity_category=EntityCategory.CONFIG,
         )
         switches.append(TPLinkVpnClientSwitch(coordinator, vpn_desc))
-        vpn.setup_vpn_entities(coordinator, entry, async_add_entities)
+        vpn_client.setup_vpn_entities(coordinator, entry, async_add_entities)
 
     async_add_entities(switches, False)
 
@@ -206,18 +206,18 @@ class TPLinkVpnClientSwitch(TPLinkRouterSwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        return self.coordinator.vpn_status.enabled
+        return self.coordinator.vpn_client_status.enabled
 
     @property
     def available(self) -> bool:
-        return self.coordinator.vpn_status is not None
+        return self.coordinator.vpn_client_status is not None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.coordinator.set_vpn_client(True)
-        self.coordinator.vpn_status.enabled = True
+        self.coordinator.vpn_client_status.enabled = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.set_vpn_client(False)
-        self.coordinator.vpn_status.enabled = False
+        self.coordinator.vpn_client_status.enabled = False
         self.async_write_ha_state()

--- a/custom_components/tplink_router/vpn_client.py
+++ b/custom_components/tplink_router/vpn_client.py
@@ -21,7 +21,7 @@ def setup_vpn_entities(
     def coordinator_updated() -> None:
         new_entities = []
 
-        for server in coordinator.vpn_status.servers:
+        for server in coordinator.vpn_client_status.servers:
             if server.id not in tracked_servers:
                 entity = TPLinkVpnServerSwitch(coordinator, server)
                 tracked_servers[server.id] = entity
@@ -29,7 +29,7 @@ def setup_vpn_entities(
             else:
                 tracked_servers[server.id].server = server
 
-        for device in coordinator.vpn_status.devices:
+        for device in coordinator.vpn_client_status.devices:
             if device.macaddr not in tracked_devices:
                 entity = TPLinkVpnDeviceSwitch(coordinator, device)
                 tracked_devices[device.macaddr] = entity
@@ -70,7 +70,7 @@ class TPLinkVpnServerSwitch(CoordinatorEntity[TPLinkRouterCoordinator], SwitchEn
     @property
     def available(self) -> bool:
         return super().available and any(
-            s.id == self._server_id for s in self.coordinator.vpn_status.servers
+            s.id == self._server_id for s in self.coordinator.vpn_client_status.servers
         )
 
     @property
@@ -96,7 +96,7 @@ class TPLinkVpnServerSwitch(CoordinatorEntity[TPLinkRouterCoordinator], SwitchEn
     @callback
     def _handle_coordinator_update(self) -> None:
         found = next(
-            (s for s in self.coordinator.vpn_status.servers if s.id == self._server_id), None
+            (s for s in self.coordinator.vpn_client_status.servers if s.id == self._server_id), None
         )
         if found is not None:
             self.server = found
@@ -131,7 +131,7 @@ class TPLinkVpnDeviceSwitch(CoordinatorEntity[TPLinkRouterCoordinator], SwitchEn
     @property
     def available(self) -> bool:
         return super().available and any(
-            d.macaddr == self._mac for d in self.coordinator.vpn_status.devices
+            d.macaddr == self._mac for d in self.coordinator.vpn_client_status.devices
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -147,7 +147,7 @@ class TPLinkVpnDeviceSwitch(CoordinatorEntity[TPLinkRouterCoordinator], SwitchEn
     @callback
     def _handle_coordinator_update(self) -> None:
         found = next(
-            (d for d in self.coordinator.vpn_status.devices if d.macaddr == self._mac), None
+            (d for d in self.coordinator.vpn_client_status.devices if d.macaddr == self._mac), None
         )
         if found is not None:
             self.device = found


### PR DESCRIPTION
Hi, I added the sensors and switches for the VPN server functionality you asked for in [PR341](https://github.com/AlexandrErohin/home-assistant-tplink-router/pull/341). Sorry this took a while. I refactored the types of the sensor and switch to play nicer with mypy and be extensible, hope that's ok.

<img width="329" height="338" alt="Screenshot 2026-06-11 at 17 10 17" src="https://github.com/user-attachments/assets/dec2a908-fcee-4b96-b811-ed1c496c6f60" />
<img width="329" height="146" alt="Screenshot 2026-06-11 at 17 10 26" src="https://github.com/user-attachments/assets/85e2ca20-1992-4db6-ac08-426ac4048f18" />

