### PR TITLE
Add serving cell sensors (band, ARFCN, modulation, bandwidth, frequency)

### DIFF
--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -78,14 +78,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vpn_client_stat = client.get_vpn_client_status()
             except Exception:
                 pass
-        return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat
+        # Check if router is serving_cells compatible
+        serving_cells = None
+        if hasattr(client, "get_lte_serving_cells"):
+            try:
+                serving_cells = client.get_lte_serving_cells()
+            except Exception:
+                pass
+        return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat, serving_cells
 
-    firmware, status, lte_status, vpn_server_stat, vpn_client_status = await hass.async_add_executor_job(
+    firmware, status, lte_status, vpn_server_stat, vpn_client_status, serving_cells = await hass.async_add_executor_job(
         TPLinkRouterCoordinator.request, client, callback
     )
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
-                                          lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status)
+                                          lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status,
+                                          serving_cells)
 
     await coordinator.async_config_entry_first_refresh()
     _async_add_listeners(hass, coordinator)

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -13,6 +13,7 @@ from tplinkrouterc6u import (
     Connection,
     LTEStatus,
     SMS,
+    ServingCell,
     VpnClientStatus,
     VPNStatus
 )
@@ -37,13 +38,14 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             unique_id: str,
             vpn_server_status: VPNStatus | None = None,
             vpn_client_status: VpnClientStatus | None = None,
+            serving_cells: list[ServingCell] | None = None,
     ) -> None:
         self.router = router
         self.unique_id = unique_id
         self.status = status
         self.tracked = {}
         self.lte_status = lte_status
-        self.serving_cells: list[dict] | None = None
+        self.serving_cells = serving_cells
         self.device_info = DeviceInfo(
             configuration_url=router.host,
             connections={(CONNECTION_NETWORK_MAC, self.status.lan_macaddr)},
@@ -135,7 +137,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.router,
                 self.router.get_lte_status,
             )
-        if self.lte_status is not None and hasattr(self.router, 'get_lte_serving_cells'):
+        if self.serving_cells is not None:
             self.serving_cells = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request,
                 self.router,

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -43,6 +43,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
         self.status = status
         self.tracked = {}
         self.lte_status = lte_status
+        self.serving_cells: list[dict] | None = None
         self.device_info = DeviceInfo(
             configuration_url=router.host,
             connections={(CONNECTION_NETWORK_MAC, self.status.lan_macaddr)},
@@ -134,6 +135,13 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.router,
                 self.router.get_lte_status,
             )
+        if self.lte_status is not None and hasattr(self.router, 'req_act'):
+            router = self.router
+            self.serving_cells = await self.hass.async_add_executor_job(
+                TPLinkRouterCoordinator.request,
+                router,
+                lambda: TPLinkRouterCoordinator._fetch_serving_cells(router),
+            )
         if self.vpn_server_status is not None:
             self.vpn_server_status = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request, self.router, self.router.get_vpn_status
@@ -161,6 +169,12 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 new_items.append(sms)
 
         self.new_sms = new_items
+
+    @staticmethod
+    def _fetch_serving_cells(router) -> list[dict]:
+        acts = [router.ActItem(router.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO')]
+        _, values = router.req_act(acts)
+        return [c for c in (values[0] if values else []) if c.get('cellConnectionStatus') == '1']
 
     @staticmethod
     def _hash_item(sms: SMS) -> str:

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -135,12 +135,11 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.router,
                 self.router.get_lte_status,
             )
-        if self.lte_status is not None and hasattr(self.router, 'req_act'):
-            router = self.router
+        if self.lte_status is not None and hasattr(self.router, 'get_lte_serving_cells'):
             self.serving_cells = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request,
-                router,
-                lambda: TPLinkRouterCoordinator._fetch_serving_cells(router),
+                self.router,
+                self.router.get_lte_serving_cells,
             )
         if self.vpn_server_status is not None:
             self.vpn_server_status = await self.hass.async_add_executor_job(
@@ -169,12 +168,6 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 new_items.append(sms)
 
         self.new_sms = new_items
-
-    @staticmethod
-    def _fetch_serving_cells(router) -> list[dict]:
-        acts = [router.ActItem(router.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO')]
-        _, values = router.req_act(acts)
-        return [c for c in (values[0] if values else []) if c.get('cellConnectionStatus') == '1']
 
     @staticmethod
     def _hash_item(sms: SMS) -> str:

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfDataRate, UnitOfInformation
+from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfDataRate, UnitOfInformation, UnitOfFrequency
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from .const import DOMAIN
@@ -36,6 +36,42 @@ class TPLinkRouterLTESensorConfig(TPLinkRouterSensorConfigBase[LTEStatus]):
 @dataclass
 class TPLinkRouterVPNServerSensorConfig(TPLinkRouterSensorConfigBase[VPNStatus]):
     sensor_type: str = "vpn_server_status"
+
+
+@dataclass
+class TPLinkRouterServingCellSensorConfig(TPLinkRouterSensorConfigBase[list]):
+    sensor_type: str = "serving_cells"
+
+
+# --- Serving cell helpers ---
+_NT_NR = '8'
+_NT_LTE_PLUS = '7'
+_NT_LTE = '3'
+
+
+def _sc(cells, nt):
+    if not cells:
+        return None
+    return next((c for c in cells if c.get('networkType') == nt), None)
+
+
+def _scf(cells, nt, field, transform=None):
+    c = _sc(cells, nt)
+    if c is None:
+        return None
+    raw = c.get(field)
+    if raw is None or raw == '' or raw == '268435455':
+        return None
+    return transform(raw) if transform else raw
+
+
+def _active_bands(cells):
+    if not cells:
+        return None
+    prefix = {_NT_LTE: 'B', _NT_LTE_PLUS: 'B', _NT_NR: 'N'}
+    parts = [f"{prefix[nt]}{_sc(cells, nt)['band']}"
+             for nt in (_NT_LTE, _NT_LTE_PLUS, _NT_NR) if _sc(cells, nt)]
+    return '+'.join(parts) if parts else None
 
 
 SENSOR_TYPES = (
@@ -276,6 +312,159 @@ LTE_SENSOR_TYPES = (
     ),
 )
 
+SERVING_CELL_SENSOR_TYPES = (
+    # Overview
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _active_bands(cells),
+        description=SensorEntityDescription(
+            key="cell_active_bands",
+            name="Active Bands",
+            icon="mdi:antenna",
+        ),
+    ),
+    # 5G NR cell
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'band', int),
+        description=SensorEntityDescription(
+            key="cell_nr_band",
+            name="NR Band",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'ARFCN', int),
+        description=SensorEntityDescription(
+            key="cell_nr_arfcn",
+            name="NR-ARFCN",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'downBandWidth', lambda v: int(v) // 1000),
+        description=SensorEntityDescription(
+            key="cell_nr_dl_bandwidth",
+            name="NR DL Bandwidth",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'downFreq', int),
+        description=SensorEntityDescription(
+            key="cell_nr_dl_freq",
+            name="NR DL Frequency",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'downlinkModType'),
+        description=SensorEntityDescription(
+            key="cell_nr_dl_mod",
+            name="NR DL Modulation",
+            icon="mdi:sine-wave",
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'uplinkModType'),
+        description=SensorEntityDescription(
+            key="cell_nr_ul_mod",
+            name="NR UL Modulation",
+            icon="mdi:sine-wave",
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'CQI', int),
+        description=SensorEntityDescription(
+            key="cell_nr_cqi",
+            name="NR CQI",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'RI', int),
+        description=SensorEntityDescription(
+            key="cell_nr_ri",
+            name="NR RI",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_NR, 'numRbs', int),
+        description=SensorEntityDescription(
+            key="cell_nr_num_rbs",
+            name="NR Resource Blocks",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    # LTE anchor cell
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'band', int),
+        description=SensorEntityDescription(
+            key="cell_lte_band",
+            name="LTE Anchor Band",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'ARFCN', int),
+        description=SensorEntityDescription(
+            key="cell_lte_arfcn",
+            name="LTE E-ARFCN",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'downBandWidth', lambda v: int(v) // 1000),
+        description=SensorEntityDescription(
+            key="cell_lte_dl_bandwidth",
+            name="LTE Anchor DL Bandwidth",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'downFreq', int),
+        description=SensorEntityDescription(
+            key="cell_lte_dl_freq",
+            name="LTE Anchor DL Frequency",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'RSRP', int),
+        description=SensorEntityDescription(
+            key="cell_lte_rsrp",
+            name="LTE Anchor RSRP",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE, 'RSRQ', int),
+        description=SensorEntityDescription(
+            key="cell_lte_rsrq",
+            name="LTE Anchor RSRQ",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
+    ),
+)
+
 VPN_SERVER_SENSOR_TYPES = (
     TPLinkRouterVPNServerSensorConfig(
         value=lambda status: status.openvpn_clients_total,
@@ -310,6 +499,10 @@ async def async_setup_entry(
 
     if coordinator.lte_status is not None:
         for sensor in LTE_SENSOR_TYPES:
+            sensors.append(TPLinkRouterSensor(coordinator, sensor))
+
+    if coordinator.lte_status is not None and hasattr(coordinator.router, 'req_act'):
+        for sensor in SERVING_CELL_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
     if coordinator.vpn_server_status is not None:

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -557,7 +557,7 @@ async def async_setup_entry(
         for sensor in LTE_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
-    if coordinator.lte_status is not None and hasattr(coordinator.router, 'get_lte_serving_cells'):
+    if coordinator.serving_cells is not None:
         for sensor in SERVING_CELL_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -13,7 +13,7 @@ from .const import DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkRouterCoordinator
-from tplinkrouterc6u import Status, LTEStatus, VPNStatus
+from tplinkrouterc6u import Status, LTEStatus, VPNStatus, ServingCell
 
 
 @dataclass
@@ -39,7 +39,7 @@ class TPLinkRouterVPNServerSensorConfig(TPLinkRouterSensorConfigBase[VPNStatus])
 
 
 @dataclass
-class TPLinkRouterServingCellSensorConfig(TPLinkRouterSensorConfigBase[list]):
+class TPLinkRouterServingCellSensorConfig(TPLinkRouterSensorConfigBase[list[ServingCell]]):
     sensor_type: str = "serving_cells"
 
 

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -463,6 +463,65 @@ SERVING_CELL_SENSOR_TYPES = (
             native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         ),
     ),
+    # LTE CA secondary cell (networkType '7', LTE+)
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'band', int),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_band",
+            name="LTE CA Band",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'ARFCN', int),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_arfcn",
+            name="LTE CA E-ARFCN",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downBandWidth', lambda v: int(v) // 1000),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_dl_bandwidth",
+            name="LTE CA DL Bandwidth",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downFreq', int),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_dl_freq",
+            name="LTE CA DL Frequency",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'RSRP', int),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_rsrp",
+            name="LTE CA RSRP",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
+    ),
+    TPLinkRouterServingCellSensorConfig(
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'RSRQ', int),
+        description=SensorEntityDescription(
+            key="cell_lte_ca_rsrq",
+            name="LTE CA RSRQ",
+            icon="mdi:antenna",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        ),
+    ),
 )
 
 VPN_SERVER_SENSOR_TYPES = (
@@ -501,7 +560,7 @@ async def async_setup_entry(
         for sensor in LTE_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
-    if coordinator.lte_status is not None and hasattr(coordinator.router, 'req_act'):
+    if coordinator.lte_status is not None and hasattr(coordinator.router, 'get_lte_serving_cells'):
         for sensor in SERVING_CELL_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -415,7 +415,7 @@ SERVING_CELL_SENSOR_TYPES = (
         value=lambda cells: _scf(cells, _NT_LTE, 'arfcn'),
         description=SensorEntityDescription(
             key="cell_lte_anchor_arfcn",
-            name="LTE E-ARFCN",
+            name="LTE Anchor E-ARFCN",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
         ),

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -44,32 +44,29 @@ class TPLinkRouterServingCellSensorConfig(TPLinkRouterSensorConfigBase[list]):
 
 
 # --- Serving cell helpers ---
-_NT_NR = '8'
-_NT_LTE_PLUS = '7'
-_NT_LTE = '3'
+_NT_NR = 8
+_NT_LTE_PLUS = 7
+_NT_LTE = 3
 
 
 def _sc(cells, nt):
     if not cells:
         return None
-    return next((c for c in cells if c.get('networkType') == nt), None)
+    return next((c for c in cells if c.network_type == nt), None)
 
 
-def _scf(cells, nt, field, transform=None):
+def _scf(cells, nt, field):
     c = _sc(cells, nt)
     if c is None:
         return None
-    raw = c.get(field)
-    if raw is None or raw == '' or raw == '268435455':
-        return None
-    return transform(raw) if transform else raw
+    return getattr(c, field)
 
 
 def _active_bands(cells):
     if not cells:
         return None
     prefix = {_NT_LTE: 'B', _NT_LTE_PLUS: 'B', _NT_NR: 'N'}
-    parts = [f"{prefix[nt]}{_sc(cells, nt)['band']}"
+    parts = [f"{prefix[nt]}{_sc(cells, nt).band}"
              for nt in (_NT_LTE, _NT_LTE_PLUS, _NT_NR) if _sc(cells, nt)]
     return '+'.join(parts) if parts else None
 
@@ -324,7 +321,7 @@ SERVING_CELL_SENSOR_TYPES = (
     ),
     # 5G NR cell
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'band', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'band'),
         description=SensorEntityDescription(
             key="cell_nr_band",
             name="NR Band",
@@ -333,7 +330,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'ARFCN', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'arfcn'),
         description=SensorEntityDescription(
             key="cell_nr_arfcn",
             name="NR-ARFCN",
@@ -342,7 +339,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'downBandWidth', lambda v: int(v) // 1000),
+        value=lambda cells: _scf(cells, _NT_NR, 'downlink_bandwidth'),
         description=SensorEntityDescription(
             key="cell_nr_dl_bandwidth",
             name="NR DL Bandwidth",
@@ -352,7 +349,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'downFreq', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'downlink_frequency'),
         description=SensorEntityDescription(
             key="cell_nr_dl_freq",
             name="NR DL Frequency",
@@ -362,7 +359,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'downlinkModType'),
+        value=lambda cells: _scf(cells, _NT_NR, 'downlink_modulation'),
         description=SensorEntityDescription(
             key="cell_nr_dl_mod",
             name="NR DL Modulation",
@@ -370,7 +367,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'uplinkModType'),
+        value=lambda cells: _scf(cells, _NT_NR, 'uplink_modulation'),
         description=SensorEntityDescription(
             key="cell_nr_ul_mod",
             name="NR UL Modulation",
@@ -378,7 +375,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'CQI', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'cqi'),
         description=SensorEntityDescription(
             key="cell_nr_cqi",
             name="NR CQI",
@@ -387,7 +384,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'RI', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'ri'),
         description=SensorEntityDescription(
             key="cell_nr_ri",
             name="NR RI",
@@ -396,7 +393,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_NR, 'numRbs', int),
+        value=lambda cells: _scf(cells, _NT_NR, 'resource_blocks'),
         description=SensorEntityDescription(
             key="cell_nr_num_rbs",
             name="NR Resource Blocks",
@@ -406,7 +403,7 @@ SERVING_CELL_SENSOR_TYPES = (
     ),
     # LTE anchor cell
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'band', int),
+        value=lambda cells: _scf(cells, _NT_LTE, 'band'),
         description=SensorEntityDescription(
             key="cell_lte_band",
             name="LTE Anchor Band",
@@ -415,7 +412,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'ARFCN', int),
+        value=lambda cells: _scf(cells, _NT_LTE, 'arfcn'),
         description=SensorEntityDescription(
             key="cell_lte_arfcn",
             name="LTE E-ARFCN",
@@ -424,7 +421,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'downBandWidth', lambda v: int(v) // 1000),
+        value=lambda cells: _scf(cells, _NT_LTE, 'downlink_bandwidth'),
         description=SensorEntityDescription(
             key="cell_lte_dl_bandwidth",
             name="LTE Anchor DL Bandwidth",
@@ -434,7 +431,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'downFreq', int),
+        value=lambda cells: _scf(cells, _NT_LTE, 'downlink_frequency'),
         description=SensorEntityDescription(
             key="cell_lte_dl_freq",
             name="LTE Anchor DL Frequency",
@@ -444,7 +441,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'RSRP', int),
+        value=lambda cells: _scf(cells, _NT_LTE, 'rsrp'),
         description=SensorEntityDescription(
             key="cell_lte_rsrp",
             name="LTE Anchor RSRP",
@@ -454,7 +451,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE, 'RSRQ', int),
+        value=lambda cells: _scf(cells, _NT_LTE, 'rsrq'),
         description=SensorEntityDescription(
             key="cell_lte_rsrq",
             name="LTE Anchor RSRQ",
@@ -463,9 +460,9 @@ SERVING_CELL_SENSOR_TYPES = (
             native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         ),
     ),
-    # LTE CA secondary cell (networkType '7', LTE+)
+    # LTE CA secondary cell (networkType 7, LTE+)
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'band', int),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'band'),
         description=SensorEntityDescription(
             key="cell_lte_ca_band",
             name="LTE CA Band",
@@ -474,7 +471,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'ARFCN', int),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'arfcn'),
         description=SensorEntityDescription(
             key="cell_lte_ca_arfcn",
             name="LTE CA E-ARFCN",
@@ -483,7 +480,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downBandWidth', lambda v: int(v) // 1000),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downlink_bandwidth'),
         description=SensorEntityDescription(
             key="cell_lte_ca_dl_bandwidth",
             name="LTE CA DL Bandwidth",
@@ -493,7 +490,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downFreq', int),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'downlink_frequency'),
         description=SensorEntityDescription(
             key="cell_lte_ca_dl_freq",
             name="LTE CA DL Frequency",
@@ -503,7 +500,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'RSRP', int),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'rsrp'),
         description=SensorEntityDescription(
             key="cell_lte_ca_rsrp",
             name="LTE CA RSRP",
@@ -513,7 +510,7 @@ SERVING_CELL_SENSOR_TYPES = (
         ),
     ),
     TPLinkRouterServingCellSensorConfig(
-        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'RSRQ', int),
+        value=lambda cells: _scf(cells, _NT_LTE_PLUS, 'rsrq'),
         description=SensorEntityDescription(
             key="cell_lte_ca_rsrq",
             name="LTE CA RSRQ",

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -405,7 +405,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'band'),
         description=SensorEntityDescription(
-            key="cell_lte_band",
+            key="cell_lte_anchor_band",
             name="LTE Anchor Band",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
@@ -414,7 +414,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'arfcn'),
         description=SensorEntityDescription(
-            key="cell_lte_arfcn",
+            key="cell_lte_anchor_arfcn",
             name="LTE E-ARFCN",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
@@ -423,7 +423,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'downlink_bandwidth'),
         description=SensorEntityDescription(
-            key="cell_lte_dl_bandwidth",
+            key="cell_lte_anchor_dl_bandwidth",
             name="LTE Anchor DL Bandwidth",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
@@ -433,7 +433,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'downlink_frequency'),
         description=SensorEntityDescription(
-            key="cell_lte_dl_freq",
+            key="cell_lte_anchor_dl_freq",
             name="LTE Anchor DL Frequency",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
@@ -443,7 +443,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'rsrp'),
         description=SensorEntityDescription(
-            key="cell_lte_rsrp",
+            key="cell_lte_anchor_rsrp",
             name="LTE Anchor RSRP",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,
@@ -453,7 +453,7 @@ SERVING_CELL_SENSOR_TYPES = (
     TPLinkRouterServingCellSensorConfig(
         value=lambda cells: _scf(cells, _NT_LTE, 'rsrq'),
         description=SensorEntityDescription(
-            key="cell_lte_rsrq",
+            key="cell_lte_anchor_rsrq",
             name="LTE Anchor RSRQ",
             icon="mdi:antenna",
             state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Hi, thanks for the integration. This adds a new set of sensors for LTE/5G NR serving cell information, fetched from the router via `DEV2_LTE_SERVING_CELL_INFO` using the `req_act` interface.

## What's added

**coordinator.py**
- New `serving_cells` field storing the list of active cells from each poll cycle
- `_fetch_serving_cells()` fetches and filters cells where `cellConnectionStatus == '1'`
- Only polled when `lte_status is not None and hasattr(router, 'req_act')`, so it has no effect on routers that don't support this

**sensor.py**
- New `TPLinkRouterServingCellSensorConfig` sensor type
- Helper functions `_sc`, `_scf`, `_active_bands` for safe field extraction (handles the router's `268435455` sentinel for unknown values)
- 16 new sensors, only registered when the router supports `req_act`:

| Sensor | Description |
|--------|-------------|
| Active Bands | Combined band string e.g. `B8+N1` |
| NR Band | 5G NR band number |
| NR-ARFCN | 5G NR absolute radio frequency channel number |
| NR DL Bandwidth | MHz |
| NR DL Frequency | MHz |
| NR DL Modulation | Downlink modulation scheme e.g. `64QAM` |
| NR UL Modulation | Uplink modulation scheme e.g. `16QAM` |
| NR CQI | Channel quality indicator |
| NR RI | Rank indicator |
| NR Resource Blocks | Number of resource blocks allocated in the NR cell |
| LTE Anchor Band | LTE frequency band number of the anchor cell |
| LTE E-ARFCN | LTE absolute radio frequency channel number of the anchor cell |
| LTE Anchor DL Bandwidth | MHz |
| LTE Anchor DL Frequency | MHz |
| LTE Anchor RSRP | dBm |
| LTE Anchor RSRQ | dBm |

Tested on NX200 with 5G NR NSA (LTE anchor + NR secondary cell).