### PR TITLE
Add 'ap_name' attribute for easymesh.

### DIFF
--- a/custom_components/tplink_router/device_tracker.py
+++ b/custom_components/tplink_router/device_tracker.py
@@ -170,6 +170,8 @@ class TPLinkTracker(CoordinatorEntity, RestoreEntity, ScannerEntity):
             attributes['traffic_usage'] = self.device.traffic_usage
         if self.device.signal is not None:
             attributes['signal'] = self.device.signal
+        if self.device.ap_name is not None:
+            attributes['ap_name'] = self.device.ap_name
         return attributes
 
     @property


### PR DESCRIPTION
This adds the ap_name attribute for device-AP association (for EasyMesh added to c6u client by [PR#188](https://github.com/AlexandrErohin/TP-Link-Archer-C6U/pull/188) on the API).

Example of dashboard code for HA display - sorted by signal level, and grouped by AP,
[Sample dashboard code.txt](https://github.com/user-attachments/files/30916549/Sample.dashboard.code.txt)
