### PR TITLE
Add customisation to suit router function.

### DIFF
--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
 from datetime import datetime
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
-from .const import DOMAIN, DEFAULT_USER, EVENT_NEW_SMS, CONF_CLIENT_CLASS
+from .const import DOMAIN, DEFAULT_USER, EVENT_NEW_SMS, CONF_CLIENT_CLASS, CONF_SUPPORT_VPN
 import logging
 from .coordinator import TPLinkRouterCoordinator
 from homeassistant.helpers import device_registry
@@ -30,6 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not (host.startswith('http://') or host.startswith('https://')):
         host = "http://{}".format(host)
     verify_ssl = entry.data[CONF_VERIFY_SSL] if CONF_VERIFY_SSL in entry.data else False
+    support_vpn = entry.data.get(CONF_SUPPORT_VPN)
     client_class = entry.data.get(CONF_CLIENT_CLASS)
     if not client_class:
         client = await TPLinkRouterCoordinator.get_client(
@@ -108,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
                                           lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status,
-                                          serving_cells)
+                                          support_vpn, serving_cells)
 
     if sms_list is not None:
         coordinator._process_sms_list(sms_list)

--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -66,20 +66,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 lte_stat = client.get_lte_status()
             except Exception:
                 pass
-        # Check if router is vpn_server compatible
+        # Check router VPN compatibility, if needed
         vpn_server_stat = None
-        if hasattr(client, "get_vpn_status"):
-            try:
-                vpn_server_stat = client.get_vpn_status()
-            except Exception:
-                pass
-        # Check if router is vpn_client compatible
         vpn_client_stat = None
-        if hasattr(client, "get_vpn_client_status"):
-            try:
-                vpn_client_stat = client.get_vpn_client_status()
-            except Exception:
-                pass
+        if support_vpn:
+            # Check if router is vpn_server compatible
+            if hasattr(client, "get_vpn_status"):
+                try:
+                    vpn_server_stat = client.get_vpn_status()
+                except Exception:
+                    pass
+            # Check if router is vpn_client compatible
+            if hasattr(client, "get_vpn_client_status"):
+                try:
+                    vpn_client_stat = client.get_vpn_client_status()
+                except Exception:
+                    pass
         # Check if router is serving_cells compatible
         serving_cells = None
         if hasattr(client, "get_lte_serving_cells"):
@@ -109,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
                                           lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status,
-                                          support_vpn, serving_cells)
+                                          serving_cells)
 
     if sms_list is not None:
         coordinator._process_sms_list(sms_list)

--- a/custom_components/tplink_router/config_flow.py
+++ b/custom_components/tplink_router/config_flow.py
@@ -5,7 +5,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.data_entry_flow import FlowResult
-from .const import DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS
+from .const import DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS, CONF_SUPPORT_VPN
 from .coordinator import TPLinkRouterCoordinator
 from homeassistant.const import (
     CONF_HOST,
@@ -29,7 +29,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Required(CONF_SCAN_INTERVAL, default=30): int,
                 vol.Required(CONF_VERIFY_SSL, default=False): cv.boolean,
-            }
+                vol.Required(CONF_SUPPORT_VPN, default=True): cv.boolean,
+            },
+            extra=vol.ALLOW_EXTRA
         )
         if user_input is not None:
             try:
@@ -70,7 +72,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_VERIFY_SSL,
                             default=user_input.get(CONF_VERIFY_SSL, False),
                         ): cv.boolean,
-                    }
+                        vol.Required(
+                            CONF_SUPPORT_VPN, 
+                            default=user_input.get(CONF_SUPPORT_VPN, False)
+                        ): cv.boolean,
+                    },
+                    extra=vol.ALLOW_EXTRA
                 )
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
@@ -107,12 +114,16 @@ class OptionsFlow(config_entries.OptionsFlowWithConfigEntry):
                 _LOGGER.error("TplinkRouter Integration Exception - %s", error)
                 errors["base"] = str(error)
 
-        data_schema = vol.Schema({
+        data_schema = vol.Schema(
+            {
             vol.Required(CONF_HOST, default=data.get(CONF_HOST)): cv.string,
             vol.Required(CONF_USERNAME, default=data.get(CONF_USERNAME, DEFAULT_USER)): cv.string,
             vol.Required(CONF_PASSWORD, default=data.get(CONF_PASSWORD)): cv.string,
             vol.Required(CONF_SCAN_INTERVAL, default=data.get(CONF_SCAN_INTERVAL)): int,
             vol.Required(CONF_VERIFY_SSL, default=data.get(CONF_VERIFY_SSL)): cv.boolean,
-        })
+            vol.Required(CONF_SUPPORT_VPN, default=data.get(CONF_SUPPORT_VPN)): cv.boolean,
+            },
+            extra=vol.ALLOW_EXTRA
+        )
 
         return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors)

--- a/custom_components/tplink_router/config_flow.py
+++ b/custom_components/tplink_router/config_flow.py
@@ -74,7 +74,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         ): cv.boolean,
                         vol.Required(
                             CONF_SUPPORT_VPN, 
-                            default=user_input.get(CONF_SUPPORT_VPN, False)
+                            default=user_input.get(CONF_SUPPORT_VPN, True)
                         ): cv.boolean,
                     },
                     extra=vol.ALLOW_EXTRA

--- a/custom_components/tplink_router/const.py
+++ b/custom_components/tplink_router/const.py
@@ -1,6 +1,7 @@
 DEFAULT_NAME = "TP-Link Router"
 DOMAIN = "tplink_router"
 CONF_CLIENT_CLASS = "client_class"
+CONF_SUPPORT_VPN = "support_vpn"
 DEFAULT_USER = "admin"
 DEFAULT_HOST = "http://192.168.0.1"
 

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -39,7 +39,6 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             unique_id: str,
             vpn_server_status: VPNStatus | None = None,
             vpn_client_status: VpnClientStatus | None = None,
-            support_vpn: bool | None = None,
             serving_cells: list[ServingCell] | None = None,
     ) -> None:
         self.router = router
@@ -58,7 +57,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             sw_version=firmware.firmware_version,
             hw_version=firmware.hardware_version,
         )
-        self.support_vpn = support_vpn
+        
         self.vpn_server_status = vpn_server_status
         self.vpn_client_status = vpn_client_status
 
@@ -143,9 +142,9 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 lte_status = self.router.get_lte_status()
             if self.serving_cells is not None:
                 serving_cells = self.router.get_lte_serving_cells()
-            if self.vpn_server_status is not None and self.support_vpn:
+            if self.vpn_server_status is not None:
                 vpn_server_status = self.router.get_vpn_status()
-            if self.vpn_client_status is not None and self.support_vpn:
+            if self.vpn_client_status is not None:
                 vpn_client_status = self.router.get_vpn_client_status()
             if hasattr(self.router, "get_sms") and self.lte_status is not None:
                 sms_list = self.router.get_sms()

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -39,6 +39,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             unique_id: str,
             vpn_server_status: VPNStatus | None = None,
             vpn_client_status: VpnClientStatus | None = None,
+            support_vpn: bool | None = None,
             serving_cells: list[ServingCell] | None = None,
     ) -> None:
         self.router = router
@@ -57,7 +58,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             sw_version=firmware.firmware_version,
             hw_version=firmware.hardware_version,
         )
-
+        self.support_vpn = support_vpn
         self.vpn_server_status = vpn_server_status
         self.vpn_client_status = vpn_client_status
 
@@ -142,9 +143,9 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 lte_status = self.router.get_lte_status()
             if self.serving_cells is not None:
                 serving_cells = self.router.get_lte_serving_cells()
-            if self.vpn_server_status is not None:
+            if self.vpn_server_status is not None and self.support_vpn:
                 vpn_server_status = self.router.get_vpn_status()
-            if self.vpn_client_status is not None:
+            if self.vpn_client_status is not None and self.support_vpn:
                 vpn_client_status = self.router.get_vpn_client_status()
             if hasattr(self.router, "get_sms") and self.lte_status is not None:
                 sms_list = self.router.get_sms()

--- a/custom_components/tplink_router/strings.json
+++ b/custom_components/tplink_router/strings.json
@@ -9,7 +9,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "support_vpn": "[%key:common::config_flow::data::support_vpn%]"
         }
       }
     }
@@ -22,7 +23,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "support_vpn": "[%key:common::config_flow::data::support_vpn%]"
         }
       }
     }

--- a/custom_components/tplink_router/translations/en.json
+++ b/custom_components/tplink_router/translations/en.json
@@ -8,7 +8,9 @@
           "username": "Login",
           "password": "Password",
           "scan_interval": "Scan interval for updates in seconds",
-          "verify_ssl": "Verify ssl for https connection"
+          "verify_ssl": "Verify ssl for https connection",
+          "support_vpn": "Include support for VPN server and client"
+
         }
       }
     }
@@ -22,7 +24,9 @@
           "username": "Login",
           "password": "Password",
           "scan_interval": "Scan interval for updates in seconds",
-          "verify_ssl": "Verify ssl for https connection"
+          "verify_ssl": "Verify ssl for https connection",
+          "support_vpn": "Include support for VPN server and client"
+
         }
       }
     }


### PR DESCRIPTION
The aim of this PR is to allow certain functions to be (de)selected, depending on the purpose of the router.

This has the potential to:
1. Remove unnecessary overhead, e.g. repetitive polling for VPN status, if VPN functions will not be used in the router.
2. Allow features to be added which are not supported by some routers, e.g. WAN failover / USB modem. To prevent issues where not supported, the user can deselect that function when configuring the integration.

Item 1 was relatively easy, and is implemented by this PR.  Reconfiguration of the option is supported.
Item 2 is now under development.

<img width="562" height="419" alt="Screenshot_support_vpn" src="https://github.com/user-attachments/assets/fe9f52a3-7f76-43bb-8154-c1916e49bfb8" />
