### PR TITLE
Add customisation option for non-AP routers.

### DIFF
--- a/custom_components/tplink_router/config_flow.py
+++ b/custom_components/tplink_router/config_flow.py
@@ -5,7 +5,9 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.data_entry_flow import FlowResult
-from .const import DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS, CONF_SUPPORT_VPN
+from .const import (
+    DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS, CONF_SUPPORT_VPN, CONF_SUPPORT_TRACKER
+)
 from .coordinator import TPLinkRouterCoordinator
 from homeassistant.const import (
     CONF_HOST,
@@ -30,6 +32,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_SCAN_INTERVAL, default=30): int,
                 vol.Required(CONF_VERIFY_SSL, default=False): cv.boolean,
                 vol.Required(CONF_SUPPORT_VPN, default=True): cv.boolean,
+                vol.Required(CONF_SUPPORT_TRACKER, default=True): cv.boolean,
             },
             extra=vol.ALLOW_EXTRA
         )
@@ -75,6 +78,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         vol.Required(
                             CONF_SUPPORT_VPN,
                             default=user_input.get(CONF_SUPPORT_VPN, True)
+                        ): cv.boolean,
+                        vol.Required(
+                            CONF_SUPPORT_TRACKER,
+                            default=user_input.get(CONF_SUPPORT_TRACKER, True)
                         ): cv.boolean,
                     },
                     extra=vol.ALLOW_EXTRA
@@ -122,6 +129,7 @@ class OptionsFlow(config_entries.OptionsFlowWithConfigEntry):
                 vol.Required(CONF_SCAN_INTERVAL, default=data.get(CONF_SCAN_INTERVAL)): int,
                 vol.Required(CONF_VERIFY_SSL, default=data.get(CONF_VERIFY_SSL)): cv.boolean,
                 vol.Required(CONF_SUPPORT_VPN, default=data.get(CONF_SUPPORT_VPN, True)): cv.boolean,
+                vol.Required(CONF_SUPPORT_TRACKER, default=data.get(CONF_SUPPORT_TRACKER, True)): cv.boolean,
             },
             extra=vol.ALLOW_EXTRA
         )

--- a/custom_components/tplink_router/const.py
+++ b/custom_components/tplink_router/const.py
@@ -2,6 +2,7 @@ DEFAULT_NAME = "TP-Link Router"
 DOMAIN = "tplink_router"
 CONF_CLIENT_CLASS = "client_class"
 CONF_SUPPORT_VPN = "support_vpn"
+CONF_SUPPORT_TRACKER = "support_tracker"
 DEFAULT_USER = "admin"
 DEFAULT_HOST = "http://192.168.0.1"
 

--- a/custom_components/tplink_router/device_tracker.py
+++ b/custom_components/tplink_router/device_tracker.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkRouterCoordinator
 from .const import (
     DOMAIN,
+    CONF_SUPPORT_TRACKER,
     EVENT_NEW_DEVICE,
     EVENT_ONLINE,
     EVENT_OFFLINE,
@@ -26,7 +27,10 @@ async def async_setup_entry(
         entry: ConfigEntry,
         async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add entitities from coordinator, otherwise restore."""
+    """ User can suppress device trackers for non-AP router """
+    if not entry.data.get(CONF_SUPPORT_TRACKER):
+        return
+    """Add entities from coordinator, otherwise restore."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     registry = entity_registry.async_get(hass)
     tracked: dict[MAC_ADDR, TPLinkTracker] = {}

--- a/custom_components/tplink_router/strings.json
+++ b/custom_components/tplink_router/strings.json
@@ -10,7 +10,8 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "support_vpn": "Include support for VPN server and client"
+          "support_vpn": "Include support for VPN server and client",
+          "support_tracker": "Include device trackers for presence detection"
         }
       }
     }
@@ -24,7 +25,8 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "support_vpn": "Include support for VPN server and client"
+          "support_vpn": "Include support for VPN server and client",
+          "support_tracker": "Include device trackers for presence detection"
         }
       }
     }

--- a/custom_components/tplink_router/translations/en.json
+++ b/custom_components/tplink_router/translations/en.json
@@ -9,8 +9,8 @@
           "password": "Password",
           "scan_interval": "Scan interval for updates in seconds",
           "verify_ssl": "Verify ssl for https connection",
-          "support_vpn": "Include support for VPN server and client"
-
+          "support_vpn": "Include support for VPN server and client",
+          "support_tracker": "Include device trackers for presence detection"
         }
       }
     }
@@ -25,8 +25,8 @@
           "password": "Password",
           "scan_interval": "Scan interval for updates in seconds",
           "verify_ssl": "Verify ssl for https connection",
-          "support_vpn": "Include support for VPN server and client"
-
+          "support_vpn": "Include support for VPN server and client",
+          "support_tracker": "Include device trackers for presence detection"
         }
       }
     }


### PR DESCRIPTION
This allows the user to suppress the creation of device trackers for a router which is not an Access Point.
For example, if a separate router is used for WAN access, and the integration is being used to monitor it and the AP, this will avoid creating a second set of device entries (which can be confusing, and contain less information than the devices created for the AP).

The approach I've used is simply to add a return statement in device_tracker.py, conditional on the user's Config Flow input.
This seems to achieve the desired result, and during testing hasn't produced any errors or warnings in the log.


<img width="568" height="289" alt="config-flow-device-tracker" src="https://github.com/user-attachments/assets/5c3639be-7a17-4a2a-9953-aba48e2a7e67" />
