### PR TITLE
Add TL-SG108E port monitoring

### DIFF
--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import device_registry
 PLATFORMS: list[Platform] = [
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,
     Platform.SWITCH,
     Platform.BUTTON,
 ]
@@ -112,6 +113,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     client.__class__.__name__,
                     err,
                 )
+        # Check if router is port_status compatible
+        port_status = None
+        if hasattr(client, "get_port_status"):
+            try:
+                port_status = client.get_port_status()
+            except Exception as err:
+                _LOGGER.debug(
+                    "TP-Link router %s: get_port_status failed: %s",
+                    client.__class__.__name__,
+                    err,
+                )
         sms_list = None
         if hasattr(client, "get_sms") and lte_stat is not None:
             try:
@@ -122,7 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     client.__class__.__name__,
                     err,
                 )
-        return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat, serving_cells, sms_list
+        return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat, serving_cells, port_status, sms_list
 
     (
         firmware,
@@ -131,6 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         vpn_server_stat,
         vpn_client_status,
         serving_cells,
+        port_status,
         sms_list,
     ) = await hass.async_add_executor_job(
         TPLinkRouterCoordinator.request, client, callback
@@ -138,7 +151,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create device coordinator and fetch data
     coordinator = TPLinkRouterCoordinator(hass, client, entry.data[CONF_SCAN_INTERVAL], firmware, status,
                                           lte_status, _LOGGER, entry.entry_id, vpn_server_stat, vpn_client_status,
-                                          serving_cells)
+                                          serving_cells, port_status)
 
     if sms_list is not None:
         coordinator._process_sms_list(sms_list)

--- a/custom_components/tplink_router/binary_sensor.py
+++ b/custom_components/tplink_router/binary_sensor.py
@@ -1,0 +1,82 @@
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from .const import DOMAIN
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .coordinator import TPLinkRouterCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    tracked: set[int] = set()
+
+    @callback
+    def coordinator_updated():
+        update_items(coordinator, async_add_entities, tracked)
+
+    entry.async_on_unload(coordinator.async_add_listener(coordinator_updated))
+    coordinator_updated()
+
+
+@callback
+def update_items(
+        coordinator: TPLinkRouterCoordinator,
+        async_add_entities: AddEntitiesCallback,
+        tracked: set[int],
+) -> None:
+    if coordinator.port_status is None:
+        return
+    new_sensors = []
+    for port in coordinator.port_status:
+        if port.port in tracked:
+            continue
+        tracked.add(port.port)
+        new_sensors.append(TPLinkRouterPortConnectivitySensor(coordinator, port.port))
+    if new_sensors:
+        async_add_entities(new_sensors)
+
+
+class TPLinkRouterPortConnectivitySensor(CoordinatorEntity[TPLinkRouterCoordinator], BinarySensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: TPLinkRouterCoordinator,
+        port: int
+    ) -> None:
+        super().__init__(coordinator)
+
+        self._port = port
+        self._attr_device_info = coordinator.device_info
+        self.entity_description = BinarySensorEntityDescription(
+            key=f"port_{port}_connectivity",
+            name=f"Port {port} connectivity",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        )
+        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{self.entity_description.key}"
+
+    @property
+    def _current_port_status(self):
+        if not self.coordinator.port_status:
+            return None
+        return next((item for item in self.coordinator.port_status if item.port == self._port), None)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        port_status = self._current_port_status
+        if port_status is None:
+            return None
+        return port_status.link_up
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return super().available and self._current_port_status is not None

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -17,7 +17,8 @@ from tplinkrouterc6u import (
     SMS,
     ServingCell,
     VpnClientStatus,
-    VPNStatus
+    VPNStatus,
+    PortStatus
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -41,6 +42,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             vpn_server_status: VPNStatus | None = None,
             vpn_client_status: VpnClientStatus | None = None,
             serving_cells: list[ServingCell] | None = None,
+            port_status: list[PortStatus] | None = None,
     ) -> None:
         self.router = router
         self.unique_id = unique_id
@@ -48,6 +50,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
         self.tracked = {}
         self.lte_status = lte_status
         self.serving_cells = serving_cells
+        self.port_status = port_status
         self.device_info = DeviceInfo(
             configuration_url=router.host,
             connections={(CONNECTION_NETWORK_MAC, self.status.lan_macaddr)},
@@ -155,6 +158,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 serving_cells = self.serving_cells
                 vpn_server_status = self.vpn_server_status
                 vpn_client_status = self.vpn_client_status
+                port_status = self.port_status
                 sms_list = None
 
                 if self.lte_status is not None:
@@ -165,6 +169,16 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                     vpn_server_status = self.router.get_vpn_status()
                 if self.vpn_client_status is not None:
                     vpn_client_status = self.router.get_vpn_client_status()
+                if hasattr(self.router, "get_port_status"):
+                    try:
+                        port_status = self.router.get_port_status()
+                    except Exception as err:
+                        self.logger.debug(
+                            "TP-Link router %s: get_port_status failed: %s",
+                            self.router.__class__.__name__,
+                            err,
+                        )
+                        port_status = None
                 if hasattr(self.router, "get_sms") and self.lte_status is not None:
                     sms_list = self.router.get_sms()
 
@@ -174,6 +188,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                     serving_cells,
                     vpn_server_status,
                     vpn_client_status,
+                    port_status,
                     sms_list,
                 )
 
@@ -183,6 +198,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                 self.serving_cells,
                 self.vpn_server_status,
                 self.vpn_client_status,
+                self.port_status,
                 sms_list,
             ) = await self.hass.async_add_executor_job(
                 TPLinkRouterCoordinator.request, self.router, callback

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from typing import Any
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorStateClass,
     SensorEntity,
     SensorEntityDescription,
@@ -14,7 +15,7 @@ from homeassistant.const import (
     UnitOfFrequency,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from .const import DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -589,6 +590,33 @@ async def async_setup_entry(
 
     async_add_entities(sensors, False)
 
+    tracked: set[int] = set()
+
+    @callback
+    def coordinator_updated():
+        update_items(coordinator, async_add_entities, tracked)
+
+    entry.async_on_unload(coordinator.async_add_listener(coordinator_updated))
+    coordinator_updated()
+
+
+@callback
+def update_items(
+        coordinator: TPLinkRouterCoordinator,
+        async_add_entities: AddEntitiesCallback,
+        tracked: set[int],
+) -> None:
+    if coordinator.port_status is None:
+        return
+    new_sensors = []
+    for port in coordinator.port_status:
+        if port.port in tracked:
+            continue
+        tracked.add(port.port)
+        new_sensors.append(TPLinkRouterPortLinkSpeedSensor(coordinator, port.port))
+    if new_sensors:
+        async_add_entities(new_sensors)
+
 
 class TPLinkRouterSensor(CoordinatorEntity[TPLinkRouterCoordinator], SensorEntity):
     _attr_has_entity_name = True
@@ -615,3 +643,60 @@ class TPLinkRouterSensor(CoordinatorEntity[TPLinkRouterCoordinator], SensorEntit
     def available(self) -> bool:
         """Return True if entity is available."""
         return self.native_value is not None
+
+
+class TPLinkRouterPortLinkSpeedSensor(CoordinatorEntity[TPLinkRouterCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: TPLinkRouterCoordinator,
+        port: int
+    ) -> None:
+        super().__init__(coordinator)
+
+        self._port = port
+        self._attr_device_info = coordinator.device_info
+        self.entity_description = SensorEntityDescription(
+            key=f"port_{port}_link_speed",
+            name=f"Port {port} link speed",
+            device_class=SensorDeviceClass.DATA_RATE,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        )
+        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{self.entity_description.key}"
+
+    @property
+    def _current_port_status(self):
+        if not self.coordinator.port_status:
+            return None
+        return next((item for item in self.coordinator.port_status if item.port == self._port), None)
+
+    @property
+    def native_value(self):
+        """Return the sensor value from current coordinator data."""
+        port_status = self._current_port_status
+        if port_status is None:
+            return None
+        return port_status.negotiated_speed
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        port_status = self._current_port_status
+        if port_status is None:
+            return None
+        return {
+            "duplex": port_status.negotiated_duplex,
+            "enabled": port_status.enabled,
+            "auto_negotiation": port_status.auto_negotiation,
+            "configured_speed": port_status.configured_speed,
+            "configured_duplex": port_status.configured_duplex,
+            "flow_control_enabled": port_status.flow_control_enabled,
+            "flow_control_active": port_status.flow_control_active,
+            "lag": port_status.lag,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return super().available and self._current_port_status is not None


### PR DESCRIPTION
Adds per-port monitoring for TL-SG108E using `get_port_status()` from `tplinkrouterc6u` 5.32.0.

Each port gets a connectivity binary sensor and a negotiated link-speed sensor. Link-speed entities also expose duplex, configured link settings, flow control and LAG as attributes. Port reads use the existing coordinator request path.

Tested on TL-SG108E v6.0 with firmware `1.0.0 Build 20230218 Rel.50633`. Port states and speeds matched the switch, and Home Assistant restart, existing Deco/SG108E entities, HACS, hassfest and flake8 all passed.