### PR TITLE
Add switch set_ipv4_dhcps (LAN DHCP server toggle).

### DIFF
--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -136,6 +136,12 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
 
         await self._run_router_request(callback)
 
+    async def set_ipv4_dhcps(self, enable: bool) -> None:
+        def callback():
+            self.router.set_ipv4_dhcps(enable)
+
+        await self._run_router_request(callback)
+
     async def send_sms(self, number: str, text: str) -> None:
         def callback():
             self.router.send_sms(number, text)

--- a/custom_components/tplink_router/switch.py
+++ b/custom_components/tplink_router/switch.py
@@ -177,6 +177,18 @@ VPN_CLIENT_SWITCH_TYPES = (
     ),
 )
 
+DHCP_SERVER_SWITCH_TYPES = (
+    TPLinkRouterStatusSwitchConfig(
+        property='lan_ipv4_dhcp_enable',
+        method=lambda coordinator, value: coordinator.set_ipv4_dhcps(value),
+        description=SwitchEntityDescription(
+            key="ipv4_dhcps",
+            name="DHCP server enable",
+            icon="mdi:server-network",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+)
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -202,6 +214,10 @@ async def async_setup_entry(
             switches.append(TPLinkRouterSwitch(coordinator, switch))
         # Dynamically register VPN Client devices & servers available on the router
         vpn_client.setup_vpn_entities(coordinator, entry, async_add_entities)
+
+    if hasattr(coordinator.router, "set_ipv4_dhcps"):
+        for switch in DHCP_SERVER_SWITCH_TYPES:
+            switches.append(TPLinkRouterSwitch(coordinator, switch))
 
     async_add_entities(switches, False)
 


### PR DESCRIPTION
This adds a switch to enable/disable LAN IPv4 DHCP server, implemented for c6u client by [PR#199](https://github.com/AlexandrErohin/TP-Link-Archer-C6U/pull/199) on the API.
Switch is created only if client has supporting method.