### PR TITLE
Add second step to Config Flow.

### DIFF
--- a/custom_components/tplink_router/config_flow.py
+++ b/custom_components/tplink_router/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.data_entry_flow import FlowResult
 from .const import (
-    DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS,
+    DOMAIN, DEFAULT_USER, DEFAULT_HOST, CONF_CLIENT_CLASS, 
     CONF_SUPPORT_VPN, CONF_SUPPORT_TRACKER, CONF_SCAN_RETRIES, CONF_SCAN_BACKOFF,
     CONF_SCAN_PAUSE, CONF_OFFLINE_TIMEOUT, DEFAULT_SCAN_RETRIES, DEFAULT_SCAN_BACKOFF,
     DEFAULT_SCAN_PAUSE, DEFAULT_OFFLINE_TIMEOUT, MAX_SCAN_RETRIES, MAX_SCAN_BACKOFF,
@@ -43,6 +43,10 @@ OFFLINE_TIMEOUT_SCHEMA = vol.All(
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
+    def __init__(self):
+        self.data_initial = {}
+        self.data = {}
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
@@ -56,20 +60,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_SCAN_PAUSE, default=DEFAULT_SCAN_PAUSE): SCAN_PAUSE_SCHEMA,
                 vol.Optional(CONF_OFFLINE_TIMEOUT, default=DEFAULT_OFFLINE_TIMEOUT): OFFLINE_TIMEOUT_SCHEMA,
                 vol.Required(CONF_VERIFY_SSL, default=False): cv.boolean,
-                vol.Required(CONF_SUPPORT_VPN, default=True): cv.boolean,
-                vol.Required(CONF_SUPPORT_TRACKER, default=True): cv.boolean,
             },
             extra=vol.ALLOW_EXTRA
         )
         if user_input is not None:
+            self.data_initial = user_input
+            return await self.async_step_custom()
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_custom(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            self.data = {**self.data_initial, **user_input}
+
             try:
                 router = await TPLinkRouterCoordinator.get_client(
                     hass=self.hass,
-                    host=user_input[CONF_HOST],
-                    password=user_input[CONF_PASSWORD],
-                    username=user_input.get(CONF_USERNAME, DEFAULT_USER),
+                    host=self.data[CONF_HOST],
+                    password=self.data[CONF_PASSWORD],
+                    username=self.data.get(CONF_USERNAME, DEFAULT_USER),
                     logger=_LOGGER,
-                    verify_ssl=user_input[CONF_VERIFY_SSL],
+                    verify_ssl=self.data[CONF_VERIFY_SSL],
                 )
 
                 def authorize_and_status():
@@ -79,56 +91,68 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(status.lan_macaddr.lower())
                 self._abort_if_unique_id_configured()
 
-                user_input[CONF_CLIENT_CLASS] = router.__class__.__name__
-                return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+                self.data[CONF_CLIENT_CLASS] = router.__class__.__name__
+                return self.async_create_entry(title=self.data[CONF_HOST], data=self.data)
+                
             except Exception as error:
                 _LOGGER.error("TplinkRouter Integration Exception - %s", error)
                 errors["base"] = str(error)
                 schema = vol.Schema(
                     {
-                        vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)): str,
+                        vol.Required(CONF_HOST, default=self.data.get(CONF_HOST, DEFAULT_HOST)): str,
                         vol.Required(CONF_PASSWORD): cv.string,
                         vol.Required(
                             CONF_USERNAME,
-                            default=user_input.get(CONF_USERNAME, DEFAULT_USER),
+                            default=self.data.get(CONF_USERNAME, DEFAULT_USER),
                         ): str,
                         vol.Required(
                             CONF_SCAN_INTERVAL,
-                            default=user_input.get(CONF_SCAN_INTERVAL, 30),
+                            default=self.data.get(CONF_SCAN_INTERVAL, 30),
                         ): int,
                         vol.Optional(
                             CONF_SCAN_RETRIES,
-                            default=user_input.get(CONF_SCAN_RETRIES, DEFAULT_SCAN_RETRIES),
+                            default=self.data.get(CONF_SCAN_RETRIES, DEFAULT_SCAN_RETRIES),
                         ): SCAN_RETRIES_SCHEMA,
                         vol.Optional(
                             CONF_SCAN_BACKOFF,
-                            default=user_input.get(CONF_SCAN_BACKOFF, DEFAULT_SCAN_BACKOFF),
+                            default=self.data.get(CONF_SCAN_BACKOFF, DEFAULT_SCAN_BACKOFF),
                         ): SCAN_BACKOFF_SCHEMA,
                         vol.Optional(
                             CONF_SCAN_PAUSE,
-                            default=user_input.get(CONF_SCAN_PAUSE, DEFAULT_SCAN_PAUSE),
+                            default=self.data.get(CONF_SCAN_PAUSE, DEFAULT_SCAN_PAUSE),
                         ): SCAN_PAUSE_SCHEMA,
                         vol.Optional(
                             CONF_OFFLINE_TIMEOUT,
-                            default=user_input.get(CONF_OFFLINE_TIMEOUT, DEFAULT_OFFLINE_TIMEOUT),
+                            default=self.data.get(CONF_OFFLINE_TIMEOUT, DEFAULT_OFFLINE_TIMEOUT),
                         ): OFFLINE_TIMEOUT_SCHEMA,
                         vol.Required(
                             CONF_VERIFY_SSL,
-                            default=user_input.get(CONF_VERIFY_SSL, False),
-                        ): cv.boolean,
-                        vol.Required(
-                            CONF_SUPPORT_VPN,
-                            default=user_input.get(CONF_SUPPORT_VPN, True)
-                        ): cv.boolean,
-                        vol.Required(
-                            CONF_SUPPORT_TRACKER,
-                            default=user_input.get(CONF_SUPPORT_TRACKER, True)
+                            default=self.data.get(CONF_VERIFY_SSL, False),
                         ): cv.boolean,
                     },
                     extra=vol.ALLOW_EXTRA
                 )
 
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+                return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+                
+        custom_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SUPPORT_VPN, 
+                    default=self.data.get(CONF_SUPPORT_VPN, True)
+                    ): cv.boolean,
+                vol.Required(
+                    CONF_SUPPORT_TRACKER, 
+                    default=self.data.get(CONF_SUPPORT_TRACKER, True)
+                    ): cv.boolean,
+            },
+            extra=vol.ALLOW_EXTRA)
+
+        return self.async_show_form(
+            step_id="custom",
+            data_schema=custom_schema,
+            errors=errors,
+        )
 
     @staticmethod
     @callback

--- a/custom_components/tplink_router/translations/en.json
+++ b/custom_components/tplink_router/translations/en.json
@@ -12,7 +12,12 @@
           "scan_backoff": "Seconds between retries",
           "scan_pause": "Minutes before data fetching re-enables automatically (0 = never)",
           "offline_timeout": "Seconds a missing device stays 'home' before going offline (0 = immediate)",
-          "verify_ssl": "Verify ssl for https connection",
+          "verify_ssl": "Verify SSL for https connection"
+        }
+      },
+      "custom": {
+        "description": "Functional Customisation:",
+        "data": {
           "support_vpn": "Include support for VPN server and client",
           "support_tracker": "Include device trackers (disable for non-access-point routers to avoid duplicates)"
         }
@@ -32,7 +37,7 @@
           "scan_backoff": "Seconds between retries",
           "scan_pause": "Minutes before data fetching re-enables automatically (0 = never)",
           "offline_timeout": "Seconds a missing device stays 'home' before going offline (0 = immediate)",
-          "verify_ssl": "Verify ssl for https connection",
+          "verify_ssl": "Verify SSL for https connection",
           "support_vpn": "Include support for VPN server and client",
           "support_tracker": "Include device trackers (disable for non-access-point routers to avoid duplicates)"
         }


### PR DESCRIPTION
This moves the functional customisation items to a second input panel (and allows for future additions).

Input data (other than password) is retained so if an error is encountered during setup, it returns to the first panel with the selections maintained.

I've left the Options Flow as a single panel, but it could be converted later if necessary.