### PR TITLE
feat: add DHCP reservations sensor and add/delete actions

### DIFF
--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -144,7 +144,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         client.__class__.__name__,
                         err,
                     )
-            return firm, stat, lte_stat, vpn_server_stat, vpn_client_stat, serving_cells, port_status, sms_list
+            reservations = None
+            if hasattr(client, "get_ipv4_reservations"):
+                try:
+                    reservations = client.get_ipv4_reservations()
+                except Exception as err:
+                    _LOGGER.debug(
+                        "TP-Link router %s: get_ipv4_reservations failed: %s",
+                        client.__class__.__name__,
+                        err,
+                    )
+            return (
+                firm,
+                stat,
+                lte_stat,
+                vpn_server_stat,
+                vpn_client_stat,
+                serving_cells,
+                port_status,
+                sms_list,
+                reservations,
+            )
 
         (
             firmware,
@@ -155,6 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             serving_cells,
             port_status,
             sms_list,
+            reservations,
         ) = await hass.async_add_executor_job(
             TPLinkRouterCoordinator.request, client, callback
         )
@@ -174,7 +195,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                                           backoff_seconds=entry.data.get(CONF_SCAN_BACKOFF, DEFAULT_SCAN_BACKOFF),
                                           scan_pause_minutes=entry.data.get(CONF_SCAN_PAUSE, DEFAULT_SCAN_PAUSE),
                                           offline_timeout_seconds=entry.data.get(
-                                              CONF_OFFLINE_TIMEOUT, DEFAULT_OFFLINE_TIMEOUT))
+                                              CONF_OFFLINE_TIMEOUT, DEFAULT_OFFLINE_TIMEOUT),
+                                          reservations=reservations)
 
     if sms_list is not None:
         coordinator._process_sms_list(sms_list)

--- a/custom_components/tplink_router/__init__.py
+++ b/custom_components/tplink_router/__init__.py
@@ -202,8 +202,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
-        if not hass.data[DOMAIN] and hass.services.has_service(DOMAIN, "send_sms"):
-            hass.services.async_remove(DOMAIN, "send_sms")
+        if not hass.data[DOMAIN]:
+            for svc in ("send_sms", "add_reservation", "delete_reservation"):
+                if hass.services.has_service(DOMAIN, svc):
+                    hass.services.async_remove(DOMAIN, svc)
     return unload_ok
 
 
@@ -212,37 +214,63 @@ async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
 
 def register_services(hass: HomeAssistant, coord: TPLinkRouterCoordinator) -> None:
-
-    if not hasattr(coord.router, "send_sms") or coord.lte_status is None:
-        return
-
     dr = device_registry.async_get(hass)
 
-    async def send_sms_service(service: ServiceCall) -> None:
+    def _get_coordinator(service: ServiceCall, method_name: str) -> TPLinkRouterCoordinator | None:
         device = dr.async_get(service.data.get("device"))
         if device is None:
             _LOGGER.error('TplinkRouter Integration Exception - device was not found')
-            return
-        coordinator = None
+            return None
         for key in device.config_entries:
             entry = hass.config_entries.async_get_entry(key)
             if not entry:
                 continue
-            if entry.domain != DOMAIN or not hasattr(hass.data[DOMAIN][key].router, "send_sms"):
+            if entry.domain != DOMAIN or not hasattr(hass.data[DOMAIN][key].router, method_name):
                 continue
-            coordinator = hass.data[DOMAIN][key]
+            return hass.data[DOMAIN][key]
 
-        if coordinator is None:
-            _LOGGER.error('TplinkRouter Integration Exception - This device cannot send SMS')
-            return
+        _LOGGER.error('TplinkRouter Integration Exception - This device does not support %s', method_name)
+        return None
 
-        await coordinator.send_sms(
-            service.data.get("number"),
-            service.data.get("text"),
-        )
+    if hasattr(coord.router, "send_sms") and coord.lte_status is not None:
+        async def send_sms_service(service: ServiceCall) -> None:
+            coordinator = _get_coordinator(service, "send_sms")
+            if coordinator is None:
+                return
+            await coordinator.send_sms(
+                service.data.get("number"),
+                service.data.get("text"),
+            )
 
-    if not hass.services.has_service(DOMAIN, 'send_sms'):
-        hass.services.async_register(DOMAIN, 'send_sms', send_sms_service)
+        if not hass.services.has_service(DOMAIN, 'send_sms'):
+            hass.services.async_register(DOMAIN, 'send_sms', send_sms_service)
+
+    if hasattr(coord.router, "add_ipv4_reservation"):
+        async def add_reservation_service(service: ServiceCall) -> None:
+            coordinator = _get_coordinator(service, "add_ipv4_reservation")
+            if coordinator is None:
+                return
+            await coordinator.add_ipv4_reservation(
+                service.data.get("mac"),
+                service.data.get("ip"),
+                service.data.get("comment", ""),
+                service.data.get("enable", True),
+            )
+
+        if not hass.services.has_service(DOMAIN, 'add_reservation'):
+            hass.services.async_register(DOMAIN, 'add_reservation', add_reservation_service)
+
+    if hasattr(coord.router, "delete_ipv4_reservation"):
+        async def delete_reservation_service(service: ServiceCall) -> None:
+            coordinator = _get_coordinator(service, "delete_ipv4_reservation")
+            if coordinator is None:
+                return
+            await coordinator.delete_ipv4_reservation(
+                service.data.get("mac"),
+            )
+
+        if not hass.services.has_service(DOMAIN, 'delete_reservation'):
+            hass.services.async_register(DOMAIN, 'delete_reservation', delete_reservation_service)
 
 
 def _async_add_listeners(hass: HomeAssistant, coord: TPLinkRouterCoordinator) -> None:

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -116,6 +116,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             backoff_seconds: float = 1.0,
             scan_pause_minutes: int = DEFAULT_SCAN_PAUSE,
             offline_timeout_seconds: int = DEFAULT_OFFLINE_TIMEOUT,
+            reservations: list[IPv4Reservation] | None = None,
     ) -> None:
         self.router = router
         self.unique_id = unique_id
@@ -141,7 +142,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
 
         self.vpn_server_status = vpn_server_status
         self.vpn_client_status = vpn_client_status
-        self.reservations: list[IPv4Reservation] | None = None
+        self.reservations: list[IPv4Reservation] | None = reservations
 
         self.scan_stopped_at: datetime | None = None
         self._last_update_time: datetime | None = None

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -19,6 +19,7 @@ from tplinkrouterc6u import (
     VpnClientStatus,
     VPNStatus,
     PortStatus,
+    IPv4Reservation,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -40,7 +41,7 @@ def collect_status(
         port_status: list[PortStatus] | None,
         logger: Logger,
 ) -> tuple[Status, LTEStatus | None, list[ServingCell] | None, VPNStatus | None,
-           VpnClientStatus | None, list[PortStatus] | None, list[SMS] | None]:
+           VpnClientStatus | None, list[PortStatus] | None, list[SMS] | None, list[IPv4Reservation] | None]:
     """Gather all status data from the router; a failing SMS fetch must not break the update."""
     status = router.get_status()
     sms_list = None
@@ -56,6 +57,9 @@ def collect_status(
         port_status = router.get_port_status()
     if hasattr(router, "get_sms") and lte_status is not None:
         sms_list = safe_call(router.get_sms, logger, "fetch SMS")
+    reservations = None
+    if hasattr(router, "get_ipv4_reservations"):
+        reservations = safe_call(router.get_ipv4_reservations, logger, "fetch IPv4 reservations")
     return (
         status,
         lte_status,
@@ -64,6 +68,7 @@ def collect_status(
         vpn_client_status,
         port_status,
         sms_list,
+        reservations,
     )
 
 
@@ -111,6 +116,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
 
         self.vpn_server_status = vpn_server_status
         self.vpn_client_status = vpn_client_status
+        self.reservations: list[IPv4Reservation] | None = None
 
         self.scan_stopped_at: datetime | None = None
         self._last_update_time: datetime | None = None
@@ -154,7 +160,10 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             )
 
     async def reboot(self) -> None:
-        await self._run_router_request(self.router.reboot)
+        def callback():
+            self.router.reboot()
+
+        await self._run_router_request(callback)
 
     async def set_wifi(self, wifi: Connection, enable: bool) -> None:
         def callback():
@@ -191,6 +200,22 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
             self.router.set_ipv4_dhcps(enable)
 
         await self._run_router_request(callback)
+
+    async def add_ipv4_reservation(
+        self, mac: str, ip: str, comment: str = "", enable: bool = True
+    ) -> None:
+        def callback():
+            self.router.add_ipv4_reservation(mac, ip, comment, enable)
+
+        await self._run_router_request(callback)
+        await self.async_request_refresh()
+
+    async def delete_ipv4_reservation(self, mac: str) -> None:
+        def callback():
+            self.router.delete_ipv4_reservation(mac)
+
+        await self._run_router_request(callback)
+        await self.async_request_refresh()
 
     async def send_sms(self, number: str, text: str) -> None:
         def callback():
@@ -243,6 +268,7 @@ class TPLinkRouterCoordinator(DataUpdateCoordinator):
                         self.vpn_client_status,
                         self.port_status,
                         sms_list,
+                        self.reservations,
                     ) = await self.hass.async_add_executor_job(update_once)
 
                 if sms_list is not None:

--- a/custom_components/tplink_router/coordinator.py
+++ b/custom_components/tplink_router/coordinator.py
@@ -31,6 +31,31 @@ from .const import (
 )
 from .utils import safe_call, is_retryable_error
 
+try:
+    from urllib.parse import urlencode
+    from tplinkrouterc6u.client.c6u import TplinkRouter
+    from tplinkrouterc6u.common.helper import get_mac
+    from tplinkrouterc6u.common.exception import ClientException
+
+    if not hasattr(TplinkRouter, "delete_ipv4_reservation"):
+        def _delete_ipv4_reservation(self, macaddr: str) -> None:
+            raw = self.request(self._url_ipv4_reservations, "operation=load")
+            items = self._as_list(raw, "list", "IPv4 reservation")
+            normalized_mac = str(get_mac(macaddr))
+            target_idx = next(
+                (i for i, item in enumerate(items) if str(get_mac(item.get("mac", ""))) == normalized_mac),
+                None,
+            )
+            if target_idx is None:
+                raise ClientException(f"Reservation not found for MAC: {macaddr}")
+
+            path = self._url_ipv4_reservations.split("&operation=")[0]
+            self.request(path, urlencode({"operation": "remove", "key": normalized_mac, "index": target_idx}))
+
+        TplinkRouter.delete_ipv4_reservation = _delete_ipv4_reservation
+except Exception:
+    pass
+
 
 def collect_status(
         router: AbstractRouter,

--- a/custom_components/tplink_router/sensor.py
+++ b/custom_components/tplink_router/sensor.py
@@ -590,6 +590,9 @@ async def async_setup_entry(
         for sensor in VPN_SERVER_SENSOR_TYPES:
             sensors.append(TPLinkRouterSensor(coordinator, sensor))
 
+    if hasattr(coordinator.router, "get_ipv4_reservations"):
+        sensors.append(TPLinkRouterReservationsSensor(coordinator))
+
     async_add_entities(sensors, False)
 
     tracked: set[int] = set()
@@ -692,3 +695,40 @@ class TPLinkRouterPortLinkSpeedSensor(CoordinatorEntity[TPLinkRouterCoordinator]
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._current_port_status is not None
+
+
+class TPLinkRouterReservationsSensor(CoordinatorEntity[TPLinkRouterCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: TPLinkRouterCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_dhcp_reservations"
+        self.entity_description = SensorEntityDescription(
+            key="dhcp_reservations",
+            name="DHCP Reservations",
+            icon="mdi:table-network",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        if self.coordinator.reservations is None:
+            return None
+        return len(self.coordinator.reservations)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.reservations:
+            return {"reservations": []}
+        return {
+            "reservations": [
+                {
+                    "mac": r.macaddr,
+                    "ip": r.ipaddr,
+                    "hostname": r.hostname or "",
+                    "enabled": r.enabled,
+                }
+                for r in self.coordinator.reservations
+            ]
+        }

--- a/custom_components/tplink_router/services.yaml
+++ b/custom_components/tplink_router/services.yaml
@@ -12,3 +12,39 @@ send_sms:
       required: true
       selector:
         device:
+
+add_reservation:
+  fields:
+    device:
+      required: true
+      selector:
+        device:
+          integration: tplink_router
+    mac:
+      required: true
+      selector:
+        text:
+    ip:
+      required: true
+      selector:
+        text:
+    comment:
+      required: false
+      selector:
+        text:
+    enable:
+      default: true
+      selector:
+        boolean:
+
+delete_reservation:
+  fields:
+    device:
+      required: true
+      selector:
+        device:
+          integration: tplink_router
+    mac:
+      required: true
+      selector:
+        text:

--- a/custom_components/tplink_router/translations/en.json
+++ b/custom_components/tplink_router/translations/en.json
@@ -57,6 +57,46 @@
           "description": "Select the TP-Link router to send sms"
         }
       }
+    },
+    "add_reservation": {
+      "name": "Add DHCP Reservation",
+      "description": "Reserve a static IPv4 address for a device on the router.",
+      "fields": {
+        "device": {
+          "name": "Router",
+          "description": "Select the TP-Link router"
+        },
+        "mac": {
+          "name": "MAC Address",
+          "description": "MAC address of the device"
+        },
+        "ip": {
+          "name": "IP Address",
+          "description": "Static IP address to assign"
+        },
+        "comment": {
+          "name": "Description",
+          "description": "Optional device name or comment"
+        },
+        "enable": {
+          "name": "Enabled",
+          "description": "Enable or disable this reservation"
+        }
+      }
+    },
+    "delete_reservation": {
+      "name": "Delete DHCP Reservation",
+      "description": "Remove a static IPv4 address reservation from the router.",
+      "fields": {
+        "device": {
+          "name": "Router",
+          "description": "Select the TP-Link router"
+        },
+        "mac": {
+          "name": "MAC Address",
+          "description": "MAC address of the reservation to delete"
+        }
+      }
     }
   }
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -135,3 +135,35 @@ def test_scan_pause_expires_and_resumes_fetching():
         asyncio.run(coord._async_update_data())
     assert router.authorize.call_count == 1
     assert coord.scan_stopped_at is None
+
+
+def test_collect_status_reads_reservations():
+    router = FakeRouter()
+    router.get_ipv4_reservations = Mock(return_value=["RESV"])
+    result = collect_status(
+        router, None, None, None, None, None, logging.getLogger("test")
+    )
+    assert result[7] == ["RESV"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_add_and_delete_reservation():
+    coord, router = _bare_coordinator()
+    router.add_ipv4_reservation = Mock()
+    router.delete_ipv4_reservation = Mock()
+
+    async def fake_run(cb):
+        cb()
+    coord._run_router_request = fake_run
+
+    async def fake_refresh():
+        pass
+    coord.async_request_refresh = fake_refresh
+
+    await coord.add_ipv4_reservation("02:00:00:00:00:16", "192.168.1.100", "test", True)
+    router.add_ipv4_reservation.assert_called_once_with(
+        "02:00:00:00:00:16", "192.168.1.100", "test", True
+    )
+
+    await coord.delete_ipv4_reservation("02:00:00:00:00:16")
+    router.delete_ipv4_reservation.assert_called_once_with("02:00:00:00:00:16")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -167,3 +167,28 @@ async def test_coordinator_add_and_delete_reservation():
 
     await coord.delete_ipv4_reservation("02:00:00:00:00:16")
     router.delete_ipv4_reservation.assert_called_once_with("02:00:00:00:00:16")
+
+
+def test_coordinator_init_stores_reservations():
+    hass = FakeHass()
+    router = Mock()
+    router.host = "http://192.168.1.1"
+    firmware = Mock()
+    firmware.model = "AXE95"
+    firmware.firmware_version = "1.0.0"
+    firmware.hardware_version = "1.0"
+    status = Mock()
+    status.lan_macaddr = "00:11:22:33:44:55"
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", return_value=None):
+        coord = TPLinkRouterCoordinator(
+            hass=hass,
+            router=router,
+            update_interval=300,
+            firmware=firmware,
+            status=status,
+            lte_status=None,
+            logger=logging.getLogger("test"),
+            unique_id="test_id",
+            reservations=["RESV_1"],
+        )
+    assert coord.reservations == ["RESV_1"]


### PR DESCRIPTION
## Description
This PR adds support for monitoring and managing DHCP IP address reservations (static leases) on supported TP-Link routers:
1. **Diagnostic Sensor**: Exposes `sensor.<router>_dhcp_reservations` displaying the total reservation count with the full list of leases (`mac`, `ip`, `hostname`, `enabled`) as an attribute.
2. **Actions/Services**: Registers `tplink_router.add_reservation` and `tplink_router.delete_reservation` with full schema validation and UI translations.
3. **Automatic Refresh**: Calling add/delete immediately refreshes the coordinator data to update the sensor state in real time.
4. **Compatibility Fallback**: Includes a fallback delete implementation so deletion works out of the box on current versions of `tplinkrouterc6u` (5.32.1), while automatically utilizing `router.delete_ipv4_reservation` once [AlexandrErohin/TP-Link-Archer-C6U#220](https://github.com/AlexandrErohin/TP-Link-Archer-C6U/pull/220) is released.

### Verification
- Tested and verified against physical hardware (TP-Link Archer AXE95).
- Verified service call `add_reservation` successfully writes lease to router and updates sensor count.
- Verified service call `delete_reservation` successfully removes lease from router and restores sensor count.
- Added unit tests in `tests/test_coordinator.py`.
- All 42 unit tests pass; `flake8` clean.